### PR TITLE
Add prototype Redshift dialect to puppetlabs-postgresql

### DIFF
--- a/manifests/globals.pp
+++ b/manifests/globals.pp
@@ -48,6 +48,7 @@ class postgresql::globals (
 
   $needs_initdb             = undef,
 
+  $dialect                  = undef,
   $encoding                 = undef,
   $locale                   = undef,
   $timezone                 = undef,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -27,6 +27,7 @@ class postgresql::params inherits postgresql::globals {
   case $::osfamily {
     'RedHat', 'Linux': {
       $link_pg_config     = true
+      $dialect            = pick($dialect, 'postgres')
       $user               = pick($user, 'postgres')
       $group              = pick($group, 'postgres')
       $needs_initdb       = pick($needs_initdb, true)

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,6 +1,7 @@
 # This installs a PostgreSQL server. See README.md for more details.
 class postgresql::server (
   $postgres_password          = undef,
+  $skip_install               = false,
 
   $package_name               = $postgresql::params::server_package_name,
   $package_ensure             = $postgresql::params::package_ensure,
@@ -46,6 +47,7 @@ class postgresql::server (
 
   $needs_initdb               = $postgresql::params::needs_initdb,
 
+  $dialect                    = $postgresql::params::dialect,
   $encoding                   = $postgresql::params::encoding,
   $locale                     = $postgresql::params::locale,
   $timezone                   = $postgresql::params::timezone,
@@ -71,13 +73,14 @@ class postgresql::server (
   }
 
   # Reload has its own ordering, specified by other defines
-  class { "${pg}::reload": require => Class["${pg}::install"] }
-
-  anchor { "${pg}::start": }
-  -> class { "${pg}::install": }
-  -> class { "${pg}::initdb": }
-  -> class { "${pg}::config": }
-  -> class { "${pg}::service": }
-  -> class { "${pg}::passwd": }
-  -> anchor { "${pg}::end": }
+  if !$skip_install {
+    class { "${pg}::reload": require => Class["${pg}::install"] }
+    anchor { "${pg}::start": }
+    -> class { "${pg}::install": }
+    -> class { "${pg}::initdb": }
+    -> class { "${pg}::config": }
+    -> class { "${pg}::service": }
+    -> class { "${pg}::passwd": }
+    -> anchor { "${pg}::end": }
+  }
 }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -73,7 +73,7 @@ class postgresql::server (
   }
 
   # Reload has its own ordering, specified by other defines
-  if !$skip_install {
+  if !$skip_install and ($dialect != 'redshift') {
     class { "${pg}::reload": require => Class["${pg}::install"] }
     anchor { "${pg}::start": }
     -> class { "${pg}::install": }

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -11,6 +11,7 @@ define postgresql::server::role(
   $replication      = false,
   $connection_limit = '-1',
   $username         = $title,
+  $dialect          = $postgresql::server::dialect,
   $connect_settings = $postgresql::server::default_connect_settings,
 ) {
   $psql_user      = $postgresql::server::user
@@ -29,6 +30,15 @@ define postgresql::server::role(
     $port_override = $postgresql::server::port
   }
 
+  # Dialect determines keyword for role definition
+  if $dialect == 'postgres' {
+    $role_keyword = "ROLE"
+  } elsif $dialect == 'redshift' {
+    $role_keyword = "USER"
+  } else {
+    fail("dialect must be set to a valid value")
+  }
+
   # If possible use the version of the remote database, otherwise
   # fallback to our local DB version
   if $connect_settings != undef and has_key( $connect_settings, 'DBVERSION') {
@@ -39,7 +49,7 @@ define postgresql::server::role(
 
   $login_sql       = $login       ? { true => 'LOGIN',       default => 'NOLOGIN' }
   $inherit_sql     = $inherit     ? { true => 'INHERIT',     default => 'NOINHERIT' }
-  $createrole_sql  = $createrole  ? { true => 'CREATEROLE',  default => 'NOCREATEROLE' }
+  $createrole_sql  = $createrole  ? { true => 'CREATE${role_keyword}',  default => 'NOCREATE${role_keyword}' }
   $createdb_sql    = $createdb    ? { true => 'CREATEDB',    default => 'NOCREATEDB' }
   $superuser_sql   = $superuser   ? { true => 'SUPERUSER',   default => 'NOSUPERUSER' }
   $replication_sql = $replication ? { true => 'REPLICATION', default => '' }
@@ -60,51 +70,51 @@ define postgresql::server::role(
     connect_settings => $connect_settings,
     cwd        => $module_workdir,
     require    => [
-      Postgresql_psql["CREATE ROLE ${username} ENCRYPTED PASSWORD ****"],
+      Postgresql_psql["CREATE ${role_keyword} ${username} ENCRYPTED PASSWORD ****"],
       Class['postgresql::server'],
     ],
   }
 
-  postgresql_psql { "CREATE ROLE ${username} ENCRYPTED PASSWORD ****":
-    command     => "CREATE ROLE \"${username}\" ${password_sql} ${login_sql} ${createrole_sql} ${createdb_sql} ${superuser_sql} ${replication_sql} CONNECTION LIMIT ${connection_limit}",
+  postgresql_psql { "CREATE ${role_keyword} ${username} ENCRYPTED PASSWORD ****":
+    command     => "CREATE ${role_keyword} \"${username}\" ${password_sql} ${login_sql} ${createrole_sql} ${createdb_sql} ${superuser_sql} ${replication_sql} CONNECTION LIMIT ${connection_limit}",
     unless      => "SELECT 1 FROM pg_roles WHERE rolname = '${username}'",
     environment => $environment,
     require     => Class['Postgresql::Server'],
   }
 
-  postgresql_psql {"ALTER ROLE \"${username}\" ${superuser_sql}":
+  postgresql_psql {"ALTER ${role_keyword} \"${username}\" ${superuser_sql}":
     unless => "SELECT 1 FROM pg_roles WHERE rolname = '${username}' AND rolsuper = ${superuser}",
   }
 
-  postgresql_psql {"ALTER ROLE \"${username}\" ${createdb_sql}":
+  postgresql_psql {"ALTER ${role_keyword} \"${username}\" ${createdb_sql}":
     unless => "SELECT 1 FROM pg_roles WHERE rolname = '${username}' AND rolcreatedb = ${createdb}",
   }
 
-  postgresql_psql {"ALTER ROLE \"${username}\" ${createrole_sql}":
+  postgresql_psql {"ALTER ${role_keyword} \"${username}\" ${createrole_sql}":
     unless => "SELECT 1 FROM pg_roles WHERE rolname = '${username}' AND rolcreaterole = ${createrole}",
   }
 
-  postgresql_psql {"ALTER ROLE \"${username}\" ${login_sql}":
+  postgresql_psql {"ALTER ${role_keyword} \"${username}\" ${login_sql}":
     unless => "SELECT 1 FROM pg_roles WHERE rolname = '${username}' AND rolcanlogin = ${login}",
   }
 
-  postgresql_psql {"ALTER ROLE \"${username}\" ${inherit_sql}":
+  postgresql_psql {"ALTER ${role_keyword} \"${username}\" ${inherit_sql}":
     unless => "SELECT 1 FROM pg_roles WHERE rolname = '${username}' AND rolinherit = ${inherit}",
   }
 
   if(versioncmp($version, '9.1') >= 0) {
     if $replication_sql == '' {
-      postgresql_psql {"ALTER ROLE \"${username}\" NOREPLICATION":
+      postgresql_psql {"ALTER ${role_keyword} \"${username}\" NOREPLICATION":
         unless => "SELECT 1 FROM pg_roles WHERE rolname = '${username}' AND rolreplication = ${replication}",
       }
     } else {
-      postgresql_psql {"ALTER ROLE \"${username}\" ${replication_sql}":
+      postgresql_psql {"ALTER ${role_keyword} \"${username}\" ${replication_sql}":
         unless => "SELECT 1 FROM pg_roles WHERE rolname = '${username}' AND rolreplication = ${replication}",
       }
     }
   }
 
-  postgresql_psql {"ALTER ROLE \"${username}\" CONNECTION LIMIT ${connection_limit}":
+  postgresql_psql {"ALTER ${role_keyword} \"${username}\" CONNECTION LIMIT ${connection_limit}":
     unless => "SELECT 1 FROM pg_roles WHERE rolname = '${username}' AND rolconnlimit = ${connection_limit}",
   }
 
@@ -115,8 +125,8 @@ define postgresql::server::role(
       $pwd_md5 = md5("${password_hash}${username}")
       $pwd_hash_sql = "md5${pwd_md5}"
     }
-    postgresql_psql { "ALTER ROLE ${username} ENCRYPTED PASSWORD ****":
-      command     => "ALTER ROLE \"${username}\" ${password_sql}",
+    postgresql_psql { "ALTER ${role_keyword} ${username} ENCRYPTED PASSWORD ****":
+      command     => "ALTER ${role_keyword} \"${username}\" ${password_sql}",
       unless      => "SELECT 1 FROM pg_shadow WHERE usename = '${username}' AND passwd = '${pwd_hash_sql}'",
       environment => $environment,
     }

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -49,7 +49,7 @@ define postgresql::server::role(
 
   $login_sql       = $login       ? { true => 'LOGIN',       default => 'NOLOGIN' }
   $inherit_sql     = $inherit     ? { true => 'INHERIT',     default => 'NOINHERIT' }
-  $createrole_sql  = $createrole  ? { true => 'CREATE${role_keyword}',  default => 'NOCREATE${role_keyword}' }
+  $createrole_sql  = $createrole  ? { true => "CREATE${role_keyword}",  default => "NOCREATE${role_keyword}" }
   $createdb_sql    = $createdb    ? { true => 'CREATEDB',    default => 'NOCREATEDB' }
   $superuser_sql   = $superuser   ? { true => 'SUPERUSER',   default => 'NOSUPERUSER' }
   $replication_sql = $replication ? { true => 'REPLICATION', default => '' }

--- a/spec/unit/classes/server_spec.rb
+++ b/spec/unit/classes/server_spec.rb
@@ -27,6 +27,18 @@ describe 'postgresql::server', :type => :class do
     end
   end
 
+  describe 'skip installation parameter' do
+
+    let(:params) {{ :skip_install => true }}
+    it { is_expected.not_to contain_class("postgresql::server::install") }
+  end
+
+  describe 'redshift skips installation' do
+
+      let(:params) {{ :dialect => 'redshift' }}
+    it { is_expected.not_to contain_class("postgresql::server::install") }
+  end
+
   describe 'service_ensure => running' do
     let(:params) do
       {

--- a/spec/unit/defines/server/db_spec.rb
+++ b/spec/unit/defines/server/db_spec.rb
@@ -28,7 +28,7 @@ describe 'postgresql::server::db', :type => :define do
     end
 
     let :pre_condition do
-      "class {'postgresql::server':}"
+      "class {'postgresql::server': dialect => 'postgres'}"
     end
 
     it { is_expected.to contain_postgresql__server__db('test') }
@@ -50,7 +50,7 @@ describe 'postgresql::server::db', :type => :define do
     end
 
     let :pre_condition do
-      "class {'postgresql::server':}"
+      "class {'postgresql::server': dialect => 'postgres'}"
     end
 
     it { is_expected.to contain_postgresql__server__database('testtest') }

--- a/spec/unit/defines/server/db_spec.rb
+++ b/spec/unit/defines/server/db_spec.rb
@@ -55,4 +55,5 @@ describe 'postgresql::server::db', :type => :define do
 
     it { is_expected.to contain_postgresql__server__database('testtest') }
   end
+
 end

--- a/spec/unit/defines/server/grant_role_spec.rb
+++ b/spec/unit/defines/server/grant_role_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe 'postgresql::server::grant_role', :type => :define do
   let :pre_condition do
-    "class { 'postgresql::server': }"
+    "class { 'postgresql::server': dialect => 'postgres'}"
   end
 
   let :facts do
@@ -120,7 +120,7 @@ describe 'postgresql::server::grant_role', :type => :define do
 
   context "with user defined" do
     let :pre_condition do
-      "class { 'postgresql::server': }
+      "class { 'postgresql::server': dialect => 'postgres'}
 postgresql::server::role { '#{params[:role]}': }"
     end
 
@@ -134,7 +134,7 @@ postgresql::server::role { '#{params[:role]}': }"
 
   context "with group defined" do
     let :pre_condition do
-      "class { 'postgresql::server': }
+      "class { 'postgresql::server': dialect => 'postgres'}
 postgresql::server::role { '#{params[:group]}': }"
     end
 

--- a/spec/unit/defines/server/role_spec.rb
+++ b/spec/unit/defines/server/role_spec.rb
@@ -24,7 +24,7 @@ describe 'postgresql::server::role', :type => :define do
   end
 
   let :pre_condition do
-   "class {'postgresql::server':}"
+   "class {'postgresql::server': dialect => 'postgres'}"
   end
 
   it { is_expected.to contain_postgresql__server__role('test') }
@@ -57,7 +57,7 @@ describe 'postgresql::server::role', :type => :define do
     end
 
     let :pre_condition do
-     "class {'postgresql::server':}"
+     "class {'postgresql::server': dialect => 'postgres'}"
     end
 
     it { is_expected.to contain_postgresql__server__role('test') }
@@ -102,7 +102,7 @@ describe 'postgresql::server::role', :type => :define do
     end
 
     let :pre_condition do
-     "class {'postgresql::server':}"
+     "class {'postgresql::server': dialect => 'postgres'}"
     end
 
     it { is_expected.to contain_postgresql__server__role('test') }

--- a/spec/unit/defines/server/role_spec.rb
+++ b/spec/unit/defines/server/role_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'postgresql::server::role', :type => :define do
+
   let :facts do
     {
       :osfamily => 'Debian',
@@ -17,32 +18,35 @@ describe 'postgresql::server::role', :type => :define do
     'test'
   end
 
-  let :params do
-    {
-      :password_hash => 'new-pa$s',
-    }
-  end
+  context 'standalone' do
 
-  let :pre_condition do
-   "class {'postgresql::server': dialect => 'postgres'}"
-  end
-
-  it { is_expected.to contain_postgresql__server__role('test') }
-  it 'should have create role for "test" user with password as ****' do
-    is_expected.to contain_postgresql_psql('CREATE ROLE test ENCRYPTED PASSWORD ****').with({
-      'command'     => "CREATE ROLE \"test\" ENCRYPTED PASSWORD '$NEWPGPASSWD' LOGIN NOCREATEROLE NOCREATEDB NOSUPERUSER  CONNECTION LIMIT -1",
-      'environment' => "NEWPGPASSWD=new-pa$s",
-      'unless'      => "SELECT 1 FROM pg_roles WHERE rolname = 'test'",
-      'port'        => "5432",
-    })
-  end
-  it 'should have alter role for "test" user with password as ****' do
-    is_expected.to contain_postgresql_psql('ALTER ROLE test ENCRYPTED PASSWORD ****').with({
-      'command'     => "ALTER ROLE \"test\" ENCRYPTED PASSWORD '$NEWPGPASSWD'",
-      'environment' => "NEWPGPASSWD=new-pa$s",
-      'unless'      => "SELECT 1 FROM pg_shadow WHERE usename = 'test' AND passwd = 'md5b6f7fcbbabb4befde4588a26c1cfd2fa'",
-      'port'        => "5432",
-    })
+    let :params do
+      {
+        :password_hash => 'new-pa$s',
+      }
+    end
+  
+    let :pre_condition do
+     "class {'postgresql::server': dialect => 'postgres'}"
+    end
+  
+    it { is_expected.to contain_postgresql__server__role('test') }
+    it 'should have create role for "test" user with password as ****' do
+      is_expected.to contain_postgresql_psql('CREATE ROLE test ENCRYPTED PASSWORD ****').with({
+        'command'     => "CREATE ROLE \"test\" ENCRYPTED PASSWORD '$NEWPGPASSWD' LOGIN NOCREATEROLE NOCREATEDB NOSUPERUSER  CONNECTION LIMIT -1",
+        'environment' => "NEWPGPASSWD=new-pa$s",
+        'unless'      => "SELECT 1 FROM pg_roles WHERE rolname = 'test'",
+        'port'        => "5432",
+      })
+    end
+    it 'should have alter role for "test" user with password as ****' do
+      is_expected.to contain_postgresql_psql('ALTER ROLE test ENCRYPTED PASSWORD ****').with({
+        'command'     => "ALTER ROLE \"test\" ENCRYPTED PASSWORD '$NEWPGPASSWD'",
+        'environment' => "NEWPGPASSWD=new-pa$s",
+        'unless'      => "SELECT 1 FROM pg_shadow WHERE usename = 'test' AND passwd = 'md5b6f7fcbbabb4befde4588a26c1cfd2fa'",
+        'port'        => "5432",
+      })
+    end
   end
 
   context "with specific db connection settings - default port" do
@@ -132,4 +136,121 @@ describe 'postgresql::server::role', :type => :define do
     end
   end
 
+  context 'standalone (redshift)' do
+
+    let :params do
+      {
+        :password_hash => 'new-pa$s',
+      }
+    end
+  
+    let :pre_condition do
+     "class {'postgresql::server': dialect => 'redshift'}"
+    end
+  
+    it { is_expected.to contain_postgresql__server__role('test') }
+    it 'should have create role for "test" user with password as ****' do
+      is_expected.to contain_postgresql_psql('CREATE USER test ENCRYPTED PASSWORD ****').with({
+        'command'     => "CREATE USER \"test\" ENCRYPTED PASSWORD '$NEWPGPASSWD' LOGIN NOCREATEUSER NOCREATEDB NOSUPERUSER  CONNECTION LIMIT -1",
+        'environment' => "NEWPGPASSWD=new-pa$s",
+        'unless'      => "SELECT 1 FROM pg_roles WHERE rolname = 'test'",
+        'port'        => "5432",
+      })
+    end
+    it 'should have alter role for "test" user with password as ****' do
+      is_expected.to contain_postgresql_psql('ALTER USER test ENCRYPTED PASSWORD ****').with({
+        'command'     => "ALTER USER \"test\" ENCRYPTED PASSWORD '$NEWPGPASSWD'",
+        'environment' => "NEWPGPASSWD=new-pa$s",
+        'unless'      => "SELECT 1 FROM pg_shadow WHERE usename = 'test' AND passwd = 'md5b6f7fcbbabb4befde4588a26c1cfd2fa'",
+        'port'        => "5432",
+      })
+    end
+  end
+
+  context "with specific db connection settings - default port (redshift)" do
+    let :params do
+      {
+        :password_hash => 'new-pa$s',
+        :connect_settings => { 'PGHOST'     => 'redshift-db-server',
+	                       'DBVERSION'  => '9.1',
+	                       'PGUSER'     => 'login-user',
+			       'PGPASSWORD' => 'login-pass' },
+      }
+    end
+
+    let :pre_condition do
+     "class {'postgresql::server': dialect => 'redshift'}"
+    end
+
+    it { is_expected.to contain_postgresql__server__role('test') }
+    it 'should have create role for "test" user with password as ****' do
+      is_expected.to contain_postgresql_psql('CREATE USER test ENCRYPTED PASSWORD ****').with({
+        'command'     => "CREATE USER \"test\" ENCRYPTED PASSWORD '$NEWPGPASSWD' LOGIN NOCREATEUSER NOCREATEDB NOSUPERUSER  CONNECTION LIMIT -1",
+        'environment' => "NEWPGPASSWD=new-pa$s",
+        'unless'      => "SELECT 1 FROM pg_roles WHERE rolname = 'test'",
+        'port'        => "5432",
+
+        'connect_settings' => { 'PGHOST'     => 'redshift-db-server',
+                                'DBVERSION'  => '9.1',
+                                'PGUSER'     => 'login-user',
+                                'PGPASSWORD' => 'login-pass' },
+      })
+    end
+    it 'should have alter role for "test" user with password as ****' do
+      is_expected.to contain_postgresql_psql('ALTER USER test ENCRYPTED PASSWORD ****').with({
+        'command'     => "ALTER USER \"test\" ENCRYPTED PASSWORD '$NEWPGPASSWD'",
+        'environment' => "NEWPGPASSWD=new-pa$s",
+        'unless'      => "SELECT 1 FROM pg_shadow WHERE usename = 'test' AND passwd = 'md5b6f7fcbbabb4befde4588a26c1cfd2fa'",
+        'port'        => "5432",
+
+        'connect_settings' => { 'PGHOST'     => 'redshift-db-server',
+                                'DBVERSION'  => '9.1',
+                                'PGUSER'     => 'login-user',
+                                'PGPASSWORD' => 'login-pass' },
+      })
+    end
+  end
+
+  context "with specific db connection settings - including port (redshift)" do
+    let :params do
+      {
+        :password_hash => 'new-pa$s',
+        :connect_settings => { 'PGHOST'     => 'redshift-db-server',
+	                       'DBVERSION'  => '9.1',
+	                       'PGPORT'     => '1234',
+	                       'PGUSER'     => 'login-user',
+			       'PGPASSWORD' => 'login-pass' },
+      }
+    end
+
+    let :pre_condition do
+     "class {'postgresql::server': dialect => 'redshift'}"
+    end
+
+    it { is_expected.to contain_postgresql__server__role('test') }
+    it 'should have create role for "test" user with password as ****' do
+      is_expected.to contain_postgresql_psql('CREATE USER test ENCRYPTED PASSWORD ****').with({
+        'command'     => "CREATE USER \"test\" ENCRYPTED PASSWORD '$NEWPGPASSWD' LOGIN NOCREATEUSER NOCREATEDB NOSUPERUSER  CONNECTION LIMIT -1",
+        'environment' => "NEWPGPASSWD=new-pa$s",
+        'unless'      => "SELECT 1 FROM pg_roles WHERE rolname = 'test'",
+        'connect_settings' => { 'PGHOST'     => 'redshift-db-server',
+                                'DBVERSION'  => '9.1',
+                                'PGPORT'     => '1234',
+                                'PGUSER'     => 'login-user',
+                                'PGPASSWORD' => 'login-pass' },
+      })
+    end
+    it 'should have alter role for "test" user with password as ****' do
+      is_expected.to contain_postgresql_psql('ALTER USER test ENCRYPTED PASSWORD ****').with({
+        'command'     => "ALTER USER \"test\" ENCRYPTED PASSWORD '$NEWPGPASSWD'",
+        'environment' => "NEWPGPASSWD=new-pa$s",
+        'unless'      => "SELECT 1 FROM pg_shadow WHERE usename = 'test' AND passwd = 'md5b6f7fcbbabb4befde4588a26c1cfd2fa'",
+        'connect_settings' => { 'PGHOST'     => 'redshift-db-server',
+                                'DBVERSION'  => '9.1',
+                                'PGPORT'     => '1234',
+                                'PGUSER'     => 'login-user',
+                                'PGPASSWORD' => 'login-pass' },
+      })
+    end
+  end
 end


### PR DESCRIPTION
Creates a prototype Redshift dialect for puppetlabs-postgresql.

For now, this is simply parameters plumbing and a minor alteration for the ROLE keyword, plus the ability to skip server setup (in the event your server is managed elsewhere).