### PR TITLE
Recursively add $title to database grants to prevent collisions

### DIFF
--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -9,10 +9,15 @@ define postgresql::server::grant (
   $psql_user        = $postgresql::server::user,
   $port             = $postgresql::server::port,
   $onlyif_exists    = false,
+  $dialect          = $postgresql::server::dialect,
   $connect_settings = $postgresql::server::default_connect_settings,
 ) {
   $group     = $postgresql::server::group
   $psql_path = $postgresql::server::psql_path
+
+  if ($dialect != 'postgres') and ($dialect != 'redshift') {
+    fail("dialect must be set to a valid value")
+  }
 
   if ! $object_name {
     $_object_name = $db

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -9,15 +9,10 @@ define postgresql::server::grant (
   $psql_user        = $postgresql::server::user,
   $port             = $postgresql::server::port,
   $onlyif_exists    = false,
-  $dialect          = $postgresql::server::dialect,
   $connect_settings = $postgresql::server::default_connect_settings,
 ) {
   $group     = $postgresql::server::group
   $psql_path = $postgresql::server::psql_path
-
-  if ($dialect != 'postgres') and ($dialect != 'redshift') {
-    fail("dialect must be set to a valid value")
-  }
 
   if ! $object_name {
     $_object_name = $db
@@ -276,7 +271,7 @@ define postgresql::server::grant (
 
   $grant_cmd = "GRANT ${_privilege} ON ${_object_type} \"${_togrant_object}\" TO
       \"${role}\""
-  postgresql_psql { "grant:${name}":
+  postgresql_psql { "${title}: grant:${name}":
     command          => $grant_cmd,
     db               => $on_db,
     port             => $port_override,
@@ -290,10 +285,10 @@ define postgresql::server::grant (
   }
 
   if($role != undef and defined(Postgresql::Server::Role[$role])) {
-    Postgresql::Server::Role[$role]->Postgresql_psql["grant:${name}"]
+    Postgresql::Server::Role[$role]->Postgresql_psql["${title}: grant:${name}"]
   }
 
   if($db != undef and defined(Postgresql::Server::Database[$db])) {
-    Postgresql::Server::Database[$db]->Postgresql_psql["grant:${name}"]
+    Postgresql::Server::Database[$db]->Postgresql_psql["${title}: grant:${name}"]
   }
 }

--- a/manifests/server/grant_role.pp
+++ b/manifests/server/grant_role.pp
@@ -6,6 +6,7 @@ define postgresql::server::grant_role (
   $psql_db          = $postgresql::server::default_database,
   $psql_user        = $postgresql::server::user,
   $port             = $postgresql::server::port,
+  $dialect          = $postgresql::server::dialect,
   $connect_settings = $postgresql::server::default_connect_settings,
 ) {
   validate_string($group)
@@ -16,6 +17,11 @@ define postgresql::server::grant_role (
   if empty($role) {
     fail('$role must be set')
   }
+
+  if $dialect != 'postgres' {
+    fail("dialect must be postgres to use this feature (for redshift, use dbgroup instead)")
+  }
+
   case $ensure {
     'present': {
       $command = "GRANT \"${group}\" TO \"${role}\""

--- a/spec/unit/defines/server/grant_spec.rb
+++ b/spec/unit/defines/server/grant_spec.rb
@@ -47,7 +47,7 @@ describe 'postgresql::server::grant', :type => :define do
     end
 
     it { is_expected.to contain_postgresql__server__grant('test') }
-    it { is_expected.to contain_postgresql_psql('grant:test').with(
+    it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
         'command' => /GRANT USAGE ON SEQUENCE "test" TO\s* "test"/m,
         'unless'  => /SELECT 1 WHERE has_sequence_privilege\('test',\s* 'test', 'USAGE'\)/m,
@@ -71,7 +71,7 @@ describe 'postgresql::server::grant', :type => :define do
     end
 
     it { is_expected.to contain_postgresql__server__grant('test') }
-    it { is_expected.to contain_postgresql_psql('grant:test').with(
+    it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
         'command' => /GRANT USAGE ON ALL SEQUENCES IN SCHEMA "public" TO\s* "test"/m,
         'unless'  => /SELECT 1 FROM \(\s*SELECT sequence_name\s* FROM information_schema\.sequences\s* WHERE sequence_schema='public'\s* EXCEPT DISTINCT\s* SELECT object_name as sequence_name\s* FROM .* WHERE .*grantee='test'\s* AND object_schema='public'\s* AND privilege_type='USAGE'\s*\) P\s* HAVING count\(P\.sequence_name\) = 0/m,
@@ -94,7 +94,7 @@ describe 'postgresql::server::grant', :type => :define do
     end
 
     it { is_expected.to contain_postgresql__server__grant('test') }
-    it { is_expected.to contain_postgresql_psql("grant:test").with_connect_settings( { 'PGHOST'    => 'postgres-db-server','DBVERSION' => '9.1' } ).with_port( 5432 ) }
+    it { is_expected.to contain_postgresql_psql("test: grant:test").with_connect_settings( { 'PGHOST'    => 'postgres-db-server','DBVERSION' => '9.1' } ).with_port( 5432 ) }
   end
 
   context "with specific db connection settings - including port" do
@@ -113,7 +113,7 @@ describe 'postgresql::server::grant', :type => :define do
     end
 
     it { is_expected.to contain_postgresql__server__grant('test') }
-    it { is_expected.to contain_postgresql_psql("grant:test").with_connect_settings( { 'PGHOST'    => 'postgres-db-server','DBVERSION' => '9.1','PGPORT'    => '1234' } ) }
+    it { is_expected.to contain_postgresql_psql("test: grant:test").with_connect_settings( { 'PGHOST'    => 'postgres-db-server','DBVERSION' => '9.1','PGPORT'    => '1234' } ) }
   end
 
   context "with specific db connection settings - port overriden by explicit parameter" do
@@ -133,7 +133,7 @@ describe 'postgresql::server::grant', :type => :define do
     end
 
     it { is_expected.to contain_postgresql__server__grant('test') }
-    it { is_expected.to contain_postgresql_psql("grant:test").with_connect_settings( { 'PGHOST'    => 'postgres-db-server','DBVERSION' => '9.1','PGPORT'    => '1234' } ).with_port( '5678' ) }
+    it { is_expected.to contain_postgresql_psql("test: grant:test").with_connect_settings( { 'PGHOST'    => 'postgres-db-server','DBVERSION' => '9.1','PGPORT'    => '1234' } ).with_port( '5678' ) }
   end
 
   context 'invalid objectype' do


### PR DESCRIPTION
Since Redshift support can manage multiple clusters, this recursively adds the $title to classes generated by database grants so similar-named permissions do not collide.

A discarded diff here also added a vacuous dialect to the grant definition file, but this has been removed until vanilla Postgres and Redshift functionality substantively deviate in the code.