### PR TITLE
Quality of life updates for roles/users

### DIFF
--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -4,6 +4,7 @@ define postgresql::server::role(
   $createdb         = false,
   $createrole       = false,
   $db               = $postgresql::server::default_database,
+  $ensure           = 'present',
   $port             = undef,
   $login            = true,
   $inherit          = true,
@@ -53,128 +54,151 @@ define postgresql::server::role(
     fail("dialect must be set to a valid value")
   }
 
-  # If possible use the version of the remote database, otherwise
-  # fallback to our local DB version
-  if $connect_settings != undef and has_key( $connect_settings, 'DBVERSION') {
-    $version = $connect_settings['DBVERSION']
+  if $ensure == 'absent' {
+    Postgresql_psql {
+      db         => $db,
+      port       => $port_override,
+      psql_user  => $psql_user,
+      psql_group => $psql_group,
+      psql_path  => $psql_path,
+      connect_settings => $connect_settings,
+      cwd        => $module_workdir,
+      require    => [
+        Postgresql_psql["${title}: DROP ${role_keyword} ${username}"],
+        Class['postgresql::server'],
+      ],
+    }
+  
+    postgresql_psql { "${title}: DROP ${role_keyword} ${username}":
+      command     => "DROP ${role_keyword} \"${username}\"",
+      unless      => "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM ${role_table} WHERE ${role_column_prefix}name = '${username}')",
+      environment => $environment,
+      require     => Class['Postgresql::Server'],
+    }
   } else {
-    $version = $postgresql::server::_version
-  }
-
-  $login_sql       = $login       ? { true => 'LOGIN',       default => 'NOLOGIN' }
-  $inherit_sql     = $inherit     ? { true => 'INHERIT',     default => 'NOINHERIT' }
-  $createrole_sql  = $createrole  ? { true => "CREATE${role_keyword}",  default => "NOCREATE${role_keyword}" }
-  $createdb_sql    = $createdb    ? { true => 'CREATEDB',    default => 'NOCREATEDB' }
-  $superuser_sql   = $superuser   ? { true => 'SUPERUSER',   default => 'NOSUPERUSER' }
-  $replication_sql = $replication ? { true => 'REPLICATION', default => '' }
-  if ($password_hash != false) {
-    $environment  = "NEWPGPASSWD=${password_hash}"
+    # If possible use the version of the remote database, otherwise
+    # fallback to our local DB version
+    if $connect_settings != undef and has_key( $connect_settings, 'DBVERSION') {
+      $version = $connect_settings['DBVERSION']
+    } else {
+      $version = $postgresql::server::_version
+    }
+  
+    $login_sql       = $login       ? { true => 'LOGIN',       default => 'NOLOGIN' }
+    $inherit_sql     = $inherit     ? { true => 'INHERIT',     default => 'NOINHERIT' }
+    $createrole_sql  = $createrole  ? { true => "CREATE${role_keyword}",  default => "NOCREATE${role_keyword}" }
+    $createdb_sql    = $createdb    ? { true => 'CREATEDB',    default => 'NOCREATEDB' }
+    $superuser_sql   = $superuser   ? { true => 'SUPERUSER',   default => 'NOSUPERUSER' }
+    $replication_sql = $replication ? { true => 'REPLICATION', default => '' }
+    if ($password_hash != false) {
+      $environment  = "NEWPGPASSWD=${password_hash}"
+      if ($dialect == 'postgres') {
+        $password_sql = "ENCRYPTED PASSWORD '\$NEWPGPASSWD'"
+      } elsif ($dialect == 'redshift') {
+        # Redshift does not define the ENCRYPTED keyword to interpret a hash
+        $password_sql = "PASSWORD '\$NEWPGPASSWD'"
+      }
+    } else {
+      if ($dialect == 'postgres') {
+        $password_sql = ''
+      } elsif ($dialect == 'redshift') {
+        $password_sql = "PASSWORD DISABLE"
+      }
+      $environment  = []
+    }
+  
+    Postgresql_psql {
+      db         => $db,
+      port       => $port_override,
+      psql_user  => $psql_user,
+      psql_group => $psql_group,
+      psql_path  => $psql_path,
+      connect_settings => $connect_settings,
+      cwd        => $module_workdir,
+      require    => [
+        Postgresql_psql["${title}: CREATE ${role_keyword} ${username} ENCRYPTED PASSWORD ****"],
+        Class['postgresql::server'],
+      ],
+    }
+  
     if ($dialect == 'postgres') {
-      $password_sql = "ENCRYPTED PASSWORD '\$NEWPGPASSWD'"
+      $options_sql = "${createrole_sql} ${createdb_sql} ${login_sql} ${superuser_sql} ${replication_sql}"
     } elsif ($dialect == 'redshift') {
-      # Redshift does not define the ENCRYPTED keyword to interpret a hash
-      $password_sql = "PASSWORD '\$NEWPGPASSWD'"
+      $options_sql = "${createrole_sql} ${createdb_sql}"
     }
-  } else {
+    
+    postgresql_psql { "${title}: CREATE ${role_keyword} ${username} ENCRYPTED PASSWORD ****":
+      command     => "CREATE ${role_keyword} \"${username}\" ${password_sql} ${options_sql} CONNECTION LIMIT ${role_connection_limit}",
+      unless      => "SELECT 1 FROM ${role_table} WHERE ${role_column_prefix}name = '${username}'",
+      environment => $environment,
+      require     => Class['Postgresql::Server'],
+    }
+  
+    postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" ${createdb_sql}":
+      command => "ALTER ${role_keyword} \"${username}\" ${createdb_sql}",
+      unless => "SELECT 1 FROM ${role_table} WHERE ${role_column_prefix}name = '${username}' AND ${role_column_prefix}createdb = ${createdb}",
+    }
+  
     if ($dialect == 'postgres') {
-      $password_sql = ''
-    } elsif ($dialect == 'redshift') {
-      $password_sql = "PASSWORD DISABLE"
-    }
-    $environment  = []
-  }
-
-  Postgresql_psql {
-    db         => $db,
-    port       => $port_override,
-    psql_user  => $psql_user,
-    psql_group => $psql_group,
-    psql_path  => $psql_path,
-    connect_settings => $connect_settings,
-    cwd        => $module_workdir,
-    require    => [
-      Postgresql_psql["${title}: CREATE ${role_keyword} ${username} ENCRYPTED PASSWORD ****"],
-      Class['postgresql::server'],
-    ],
-  }
-
-  if ($dialect == 'postgres') {
-    $options_sql = "${createrole_sql} ${createdb_sql} ${login_sql} ${superuser_sql} ${replication_sql}"
-  } elsif ($dialect == 'redshift') {
-    $options_sql = "${createrole_sql} ${createdb_sql}"
-  }
+      postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" ${createrole_sql}":
+        command => "ALTER ${role_keyword} \"${username}\" ${createrole_sql}",
+        unless => "SELECT 1 FROM ${role_table} WHERE ${role_column_prefix}name = '${username}' AND rolcreaterole = ${createrole}",
+      }
   
-  postgresql_psql { "${title}: CREATE ${role_keyword} ${username} ENCRYPTED PASSWORD ****":
-    command     => "CREATE ${role_keyword} \"${username}\" ${password_sql} ${options_sql} CONNECTION LIMIT ${role_connection_limit}",
-    unless      => "SELECT 1 FROM ${role_table} WHERE ${role_column_prefix}name = '${username}'",
-    environment => $environment,
-    require     => Class['Postgresql::Server'],
-  }
-
-  postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" ${createdb_sql}":
-    command => "ALTER ${role_keyword} \"${username}\" ${createdb_sql}",
-    unless => "SELECT 1 FROM ${role_table} WHERE ${role_column_prefix}name = '${username}' AND ${role_column_prefix}createdb = ${createdb}",
-  }
-
-  if ($dialect == 'postgres') {
-    postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" ${createrole_sql}":
-      command => "ALTER ${role_keyword} \"${username}\" ${createrole_sql}",
-      unless => "SELECT 1 FROM ${role_table} WHERE ${role_column_prefix}name = '${username}' AND rolcreaterole = ${createrole}",
-    }
-
-    postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" ${superuser_sql}":
-      command => "ALTER ${role_keyword} \"${username}\" ${superuser_sql}",
-      unless => "SELECT 1 FROM ${role_table} WHERE rolname = '${username}' AND rolsuper = ${superuser}",
-    }
-  
-    postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" ${login_sql}":
-      command => "ALTER ${role_keyword} \"${username}\" ${login_sql}",
-      unless => "SELECT 1 FROM ${role_table} WHERE rolname = '${username}' AND rolcanlogin = ${login}",
-    }
-  
-    postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" ${inherit_sql}":
-      command => "ALTER ${role_keyword} \"${username}\" ${inherit_sql}",
-      unless => "SELECT 1 FROM ${role_table} WHERE rolname = '${username}' AND rolinherit = ${inherit}",
-    }
-  
-    if(versioncmp($version, '9.1') >= 0) {
-      if $replication_sql == '' {
-        postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" NOREPLICATION":
-          command => "ALTER ${role_keyword} \"${username}\" NOREPLICATION",
-          unless => "SELECT 1 FROM ${role_table} WHERE rolname = '${username}' AND rolreplication = ${replication}",
-        }
-      } else {
-        postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" ${replication_sql}":
-          command => "ALTER ${role_keyword} \"${username}\" ${replication_sql}",
-          unless => "SELECT 1 FROM ${role_table} WHERE rolname = '${username}' AND rolreplication = ${replication}",
+      postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" ${superuser_sql}":
+        command => "ALTER ${role_keyword} \"${username}\" ${superuser_sql}",
+        unless => "SELECT 1 FROM ${role_table} WHERE rolname = '${username}' AND rolsuper = ${superuser}",
+      }
+    
+      postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" ${login_sql}":
+        command => "ALTER ${role_keyword} \"${username}\" ${login_sql}",
+        unless => "SELECT 1 FROM ${role_table} WHERE rolname = '${username}' AND rolcanlogin = ${login}",
+      }
+    
+      postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" ${inherit_sql}":
+        command => "ALTER ${role_keyword} \"${username}\" ${inherit_sql}",
+        unless => "SELECT 1 FROM ${role_table} WHERE rolname = '${username}' AND rolinherit = ${inherit}",
+      }
+    
+      if(versioncmp($version, '9.1') >= 0) {
+        if $replication_sql == '' {
+          postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" NOREPLICATION":
+            command => "ALTER ${role_keyword} \"${username}\" NOREPLICATION",
+            unless => "SELECT 1 FROM ${role_table} WHERE rolname = '${username}' AND rolreplication = ${replication}",
+          }
+        } else {
+          postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" ${replication_sql}":
+            command => "ALTER ${role_keyword} \"${username}\" ${replication_sql}",
+            unless => "SELECT 1 FROM ${role_table} WHERE rolname = '${username}' AND rolreplication = ${replication}",
+          }
         }
       }
+    } elsif ($dialect == 'redshift') {
+  
+      # CREATEUSER actually defines superuser privileges in Redshift: http://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_USER.html
+      postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" ${createrole_sql}":
+        command => "ALTER ${role_keyword} \"${username}\" ${createrole_sql}",
+        unless => "SELECT 1 FROM ${role_table} WHERE usename = '${username}' AND usesuper = ${createrole}",
+      }
     }
-  } elsif ($dialect == 'redshift') {
-
-    # CREATEUSER actually defines superuser privileges in Redshift: http://docs.aws.amazon.com/redshift/latest/dg/r_CREATE_USER.html
-    postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" ${createrole_sql}":
-      command => "ALTER ${role_keyword} \"${username}\" ${createrole_sql}",
-      unless => "SELECT 1 FROM ${role_table} WHERE usename = '${username}' AND usesuper = ${createrole}",
+  
+    postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" CONNECTION LIMIT ${role_connection_limit}":
+      command => "ALTER ${role_keyword} \"${username}\" CONNECTION LIMIT ${role_connection_limit}",
+      unless => "SELECT 1 FROM ${role_table} WHERE ${role_column_prefix}name = '${username}' AND ${role_column_prefix}connlimit = '${role_connection_limit}'",
     }
-  }
-
-  postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" CONNECTION LIMIT ${role_connection_limit}":
-    command => "ALTER ${role_keyword} \"${username}\" CONNECTION LIMIT ${role_connection_limit}",
-    unless => "SELECT 1 FROM ${role_table} WHERE ${role_column_prefix}name = '${username}' AND ${role_column_prefix}connlimit = '${role_connection_limit}'",
-  }
-
-  if $password_hash {
-    if($password_hash =~ /^md5.+/) {
-      $pwd_hash_sql = $password_hash
-    } else {
-      $pwd_md5 = md5("${password_hash}${username}")
-      $pwd_hash_sql = "md5${pwd_md5}"
-    }
-    postgresql_psql { "${title}: ALTER ${role_keyword} ${username} ENCRYPTED PASSWORD ****":
-      command     => "ALTER ${role_keyword} \"${username}\" ${password_sql}",
-      unless      => "SELECT 1 FROM ${password_table} WHERE usename = '${username}' AND passwd = '${pwd_hash_sql}'",
-      environment => $environment,
+  
+    if $password_hash {
+      if($password_hash =~ /^md5.+/) {
+        $pwd_hash_sql = $password_hash
+      } else {
+        $pwd_md5 = md5("${password_hash}${username}")
+        $pwd_hash_sql = "md5${pwd_md5}"
+      }
+      postgresql_psql { "${title}: ALTER ${role_keyword} ${username} ENCRYPTED PASSWORD ****":
+        command     => "ALTER ${role_keyword} \"${username}\" ${password_sql}",
+        unless      => "SELECT 1 FROM ${password_table} WHERE usename = '${username}' AND passwd = '${pwd_hash_sql}'",
+        environment => $environment,
+      }
     }
   }
 }

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -56,14 +56,14 @@ define postgresql::server::role(
 
   if $ensure == 'absent' {
     Postgresql_psql {
-      db         => $db,
-      port       => $port_override,
-      psql_user  => $psql_user,
-      psql_group => $psql_group,
-      psql_path  => $psql_path,
+      db               => $db,
+      port             => $port_override,
+      psql_user        => $psql_user,
+      psql_group       => $psql_group,
+      psql_path        => $psql_path,
       connect_settings => $connect_settings,
-      cwd        => $module_workdir,
-      require    => [
+      cwd              => $module_workdir,
+      require          => [
         Postgresql_psql["${title}: DROP ${role_keyword} ${username}"],
         Class['postgresql::server'],
       ],
@@ -116,14 +116,14 @@ define postgresql::server::role(
     }
   
     Postgresql_psql {
-      db         => $db,
-      port       => $port_override,
-      psql_user  => $psql_user,
-      psql_group => $psql_group,
-      psql_path  => $psql_path,
+      db               => $db,
+      port             => $port_override,
+      psql_user        => $psql_user,
+      psql_group       => $psql_group,
+      psql_path        => $psql_path,
       connect_settings => $connect_settings,
-      cwd        => $module_workdir,
-      require    => [
+      cwd              => $module_workdir,
+      require          => [
         Postgresql_psql["${title}: CREATE ${role_keyword} ${username} ENCRYPTED PASSWORD ****"],
         Class['postgresql::server'],
       ],

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -84,7 +84,15 @@ define postgresql::server::role(
       $version = $postgresql::server::_version
     }
   
-    $login_sql       = $login       ? { true => 'LOGIN',       default => 'NOLOGIN' }
+    if ($dialect == 'postgres') {
+      $login_sql       = $login       ? { true => 'LOGIN',       default => 'NOLOGIN' }
+    } elsif ($dialect == 'redshift') {
+      if ($login != false) {
+        $login_sql = $login
+      } else {
+        $login_sql = ''
+      }
+    }
     $inherit_sql     = $inherit     ? { true => 'INHERIT',     default => 'NOINHERIT' }
     $createrole_sql  = $createrole  ? { true => "CREATE${role_keyword}",  default => "NOCREATE${role_keyword}" }
     $createdb_sql    = $createdb    ? { true => 'CREATEDB',    default => 'NOCREATEDB' }
@@ -179,6 +187,12 @@ define postgresql::server::role(
       postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" ${createrole_sql}":
         command => "ALTER ${role_keyword} \"${username}\" ${createrole_sql}",
         unless => "SELECT 1 FROM ${role_table} WHERE usename = '${username}' AND usesuper = ${createrole}",
+      }
+
+      # $login can act as a string in Redshift, which is useful for passing PASSWORD DISABLE
+      postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" ${login_sql}":
+        command => "ALTER ${role_keyword} \"${username}\" ${login_sql}",
+        unless => "SELECT 1 FROM ${password_table} WHERE usename = '${username}' AND passwd = ''",
       }
     }
   

--- a/spec/unit/defines/server/role_spec.rb
+++ b/spec/unit/defines/server/role_spec.rb
@@ -240,6 +240,29 @@ describe 'postgresql::server::role', :type => :define do
     end
   end
 
+  context 'login set to PASSWORD DISABLE (redshift)' do
+
+    let :params do
+      {
+        :login => "PASSWORD DISABLE",
+      }
+    end
+  
+    let :pre_condition do
+     "class {'postgresql::server': dialect => 'redshift'}"
+    end
+  
+    it { is_expected.to contain_postgresql__server__role('test') }
+    it 'should have an alter statement to set PASSWORD DISABLE' do
+      is_expected.to contain_postgresql_psql('test: ALTER USER "test" PASSWORD DISABLE').with({
+        'command'     => "ALTER USER \"test\" PASSWORD DISABLE",
+        'environment' => [],
+        'unless'      => "SELECT 1 FROM pg_user WHERE usename = 'test' AND passwd = ''",
+        'port'        => "5432",
+      })
+    end
+  end
+
   context "with specific db connection settings - default port (redshift)" do
     let :params do
       {

--- a/spec/unit/defines/server/role_spec.rb
+++ b/spec/unit/defines/server/role_spec.rb
@@ -157,6 +157,37 @@ describe 'postgresql::server::role', :type => :define do
     end
   end
 
+  context "drop user" do
+    let :params do
+      {
+        :connect_settings => { 'PGHOST'     => 'postgres-db-server',
+                           'DBVERSION'  => '9.1',
+                           'PGPORT'     => '1234',
+                           'PGUSER'     => 'login-user',
+                           'PGPASSWORD' => 'login-pass' },
+        :ensure => 'absent',
+      }
+    end
+
+    let :pre_condition do
+     "class {'postgresql::server': dialect => 'postgres'}"
+    end
+
+    it { is_expected.to contain_postgresql__server__role('test') }
+    it 'should have drop role for "test" user' do
+      is_expected.to contain_postgresql_psql('test: DROP ROLE test').with({
+        'command'     => "DROP ROLE \"test\"",
+        'environment' => ["rp_env"],
+        'unless'      => "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'test')",
+        'connect_settings' => { 'PGHOST'     => 'postgres-db-server',
+                                'DBVERSION'  => '9.1',
+                                'PGPORT'     => '1234',
+                                'PGUSER'     => 'login-user',
+                                'PGPASSWORD' => 'login-pass' },
+      })
+    end
+  end
+
   context 'standalone (redshift)' do
 
     let :params do
@@ -287,6 +318,37 @@ describe 'postgresql::server::role', :type => :define do
         'command'     => "ALTER USER \"test\" PASSWORD '$NEWPGPASSWD'",
         'environment' => "NEWPGPASSWD=new-pa$s",
         'unless'      => "SELECT 1 FROM pg_user WHERE usename = 'test' AND passwd = 'md5b6f7fcbbabb4befde4588a26c1cfd2fa'",
+        'connect_settings' => { 'PGHOST'     => 'redshift-db-server',
+                                'DBVERSION'  => '9.1',
+                                'PGPORT'     => '1234',
+                                'PGUSER'     => 'login-user',
+                                'PGPASSWORD' => 'login-pass' },
+      })
+    end
+  end
+
+  context "drop user (redshift)" do
+    let :params do
+      {
+        :connect_settings => { 'PGHOST'     => 'redshift-db-server',
+                           'DBVERSION'  => '9.1',
+                           'PGPORT'     => '1234',
+                           'PGUSER'     => 'login-user',
+                           'PGPASSWORD' => 'login-pass' },
+        :ensure => 'absent',
+      }
+    end
+
+    let :pre_condition do
+     "class {'postgresql::server': dialect => 'redshift'}"
+    end
+
+    it { is_expected.to contain_postgresql__server__role('test') }
+    it 'should have drop role for "test" user' do
+      is_expected.to contain_postgresql_psql('test: DROP USER test').with({
+        'command'     => "DROP USER \"test\"",
+        'environment' => ["rp_env"],
+        'unless'      => "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM pg_user_info WHERE usename = 'test')",
         'connect_settings' => { 'PGHOST'     => 'redshift-db-server',
                                 'DBVERSION'  => '9.1',
                                 'PGPORT'     => '1234',

--- a/spec/unit/defines/server/role_spec.rb
+++ b/spec/unit/defines/server/role_spec.rb
@@ -213,7 +213,6 @@ describe 'postgresql::server::role', :type => :define do
       is_expected.to contain_postgresql_psql('test: ALTER USER test ENCRYPTED PASSWORD ****').with({
         'command'     => "ALTER USER \"test\" PASSWORD '$NEWPGPASSWD'",
         'environment' => "NEWPGPASSWD=new-pa$s",
-        'unless'      => "SELECT 1 FROM pg_user WHERE usename = 'test' AND passwd = 'md5b6f7fcbbabb4befde4588a26c1cfd2fa'",
         'port'        => "5432",
       })
     end
@@ -257,7 +256,6 @@ describe 'postgresql::server::role', :type => :define do
       is_expected.to contain_postgresql_psql('test: ALTER USER "test" PASSWORD DISABLE').with({
         'command'     => "ALTER USER \"test\" PASSWORD DISABLE",
         'environment' => [],
-        'unless'      => "SELECT 1 FROM pg_user WHERE usename = 'test' AND passwd = ''",
         'port'        => "5432",
       })
     end
@@ -296,7 +294,6 @@ describe 'postgresql::server::role', :type => :define do
       is_expected.to contain_postgresql_psql('test: ALTER USER test ENCRYPTED PASSWORD ****').with({
         'command'     => "ALTER USER \"test\" PASSWORD '$NEWPGPASSWD'",
         'environment' => "NEWPGPASSWD=new-pa$s",
-        'unless'      => "SELECT 1 FROM pg_user WHERE usename = 'test' AND passwd = 'md5b6f7fcbbabb4befde4588a26c1cfd2fa'",
         'port'        => "5432",
 
         'connect_settings' => { 'PGHOST'     => 'redshift-db-server',
@@ -340,7 +337,6 @@ describe 'postgresql::server::role', :type => :define do
       is_expected.to contain_postgresql_psql('test: ALTER USER test ENCRYPTED PASSWORD ****').with({
         'command'     => "ALTER USER \"test\" PASSWORD '$NEWPGPASSWD'",
         'environment' => "NEWPGPASSWD=new-pa$s",
-        'unless'      => "SELECT 1 FROM pg_user WHERE usename = 'test' AND passwd = 'md5b6f7fcbbabb4befde4588a26c1cfd2fa'",
         'connect_settings' => { 'PGHOST'     => 'redshift-db-server',
                                 'DBVERSION'  => '9.1',
                                 'PGPORT'     => '1234',


### PR DESCRIPTION
Several minor feature additions:

* Adds the ability to ensure => absent to drop roles and users
* Adds the ability to specify PASSWORD DISABLE on user updates in Redshift
* Fixes a pg_shadow issue in Redshift. Since superusers can no longer query this catalog, password updates will always be run by Puppet.