### PR TITLE
Use curly brace format instead of explicit ARRAY keyword when specifying Redshift group members

### DIFF
--- a/manifests/server/dbgroup.pp
+++ b/manifests/server/dbgroup.pp
@@ -44,8 +44,8 @@ define postgresql::server::dbgroup(
     require     => Class['Postgresql::Server'],
   }
 
-  postgresql_psql {"${title}: UPDATE pg_group SET grolist = ARRAY${groupmembers} WHERE groname = '${groupname}'":
-    command => "UPDATE pg_group SET grolist = ARRAY${groupmembers} WHERE groname = '${groupname}'",
-    unless => "SELECT 1 FROM pg_group WHERE groname = '${groupname}' AND grolist = ARRAY${groupmembers}",
+  postgresql_psql {"${title}: UPDATE pg_group SET grolist = '${groupmembers}' WHERE groname = '${groupname}'":
+    command => "UPDATE pg_group SET grolist = '${groupmembers}' WHERE groname = '${groupname}'",
+    unless => "SELECT 1 FROM pg_group WHERE groname = '${groupname}' AND grolist = '${groupmembers}'",
   }
 }

--- a/manifests/server/dbgroup.pp
+++ b/manifests/server/dbgroup.pp
@@ -2,7 +2,7 @@
 define postgresql::server::dbgroup(
   $db               = $postgresql::server::default_database,
   $port             = undef, 
-  $groupmembers     = [],
+  $groupmembers     = '{}',
   $groupname        = $title,
   $dialect          = $postgresql::server::dialect,
   $connect_settings = undef,

--- a/spec/unit/defines/server/dbgroup_spec.rb
+++ b/spec/unit/defines/server/dbgroup_spec.rb
@@ -33,11 +33,10 @@ describe 'postgresql::server::dbgroup', :type => :define do
         'port'        => "5432",
       })
     end
-    it 'should have update pg_group for test group with groupmembers as []' do
-      is_expected.to contain_postgresql_psql("test: UPDATE pg_group SET grolist = ARRAY[] WHERE groname = 'test'").with({
-        'command'     => "UPDATE pg_group SET grolist = ARRAY[] WHERE groname = 'test'",
-        'environment' => [],
-        'unless'      => "SELECT 1 FROM pg_group WHERE groname = 'test' AND grolist = ARRAY[]",
+    it 'should have update pg_group for test group with groupmembers as {}' do
+      is_expected.to contain_postgresql_psql("test: UPDATE pg_group SET grolist = '{}' WHERE groname = 'test'").with({
+        'command'     => "UPDATE pg_group SET grolist = '{}' WHERE groname = 'test'",
+        'unless'      => "SELECT 1 FROM pg_group WHERE groname = 'test' AND grolist = '{}'",
         'port'        => "5432",
       })
     end
@@ -51,7 +50,7 @@ describe 'postgresql::server::dbgroup', :type => :define do
   
     let :params do
       {
-        :groupmembers => ['testuser1', 'testuser2'],
+        :groupmembers => "{\"testuser1\", \"testuser2\"}",
       }
     end
 
@@ -65,10 +64,9 @@ describe 'postgresql::server::dbgroup', :type => :define do
       })
     end
     it 'should have update pg_group for test group with provided groupmembers' do
-      is_expected.to contain_postgresql_psql("test: UPDATE pg_group SET grolist = ARRAY[testuser1, testuser2] WHERE groname = 'test'").with({
-        'command'     => "UPDATE pg_group SET grolist = ARRAY[testuser1, testuser2] WHERE groname = 'test'",
-        'environment' => [],
-        'unless'      => "SELECT 1 FROM pg_group WHERE groname = 'test' AND grolist = ARRAY[testuser1, testuser2]",
+      is_expected.to contain_postgresql_psql("test: UPDATE pg_group SET grolist = '{\"testuser1\", \"testuser2\"}' WHERE groname = 'test'").with({
+        'command'     => "UPDATE pg_group SET grolist = '{\"testuser1\", \"testuser2\"}' WHERE groname = 'test'",
+        'unless'      => "SELECT 1 FROM pg_group WHERE groname = 'test' AND grolist = '{\"testuser1\", \"testuser2\"}'",
         'port'        => "5432",
       })
     end

--- a/spec/unit/defines/server/dbgroup_spec.rb
+++ b/spec/unit/defines/server/dbgroup_spec.rb
@@ -50,7 +50,7 @@ describe 'postgresql::server::dbgroup', :type => :define do
   
     let :params do
       {
-        :groupmembers => "{\"testuser1\", \"testuser2\"}",
+        :groupmembers => ['testuser1', 'testuser2'],
       }
     end
 

--- a/spec/unit/defines/server/role_spec.rb
+++ b/spec/unit/defines/server/role_spec.rb
@@ -255,7 +255,6 @@ describe 'postgresql::server::role', :type => :define do
     it 'should have an alter statement to set PASSWORD DISABLE' do
       is_expected.to contain_postgresql_psql('test: ALTER USER "test" PASSWORD DISABLE').with({
         'command'     => "ALTER USER \"test\" PASSWORD DISABLE",
-        'environment' => [],
         'port'        => "5432",
       })
     end


### PR DESCRIPTION
This patch uses curly brace notation instead of the `ARRAY` keyword for Redshift group member specification. The default is also now updated to `'{}'` accordingly.

This should simplify the amount of typing required for specifying group members, as well as making error messages in group specification easier to understand.