### PR TITLE
Remove support for PASSWORD DISABLE alter statements

### DIFF
--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -84,15 +84,7 @@ define postgresql::server::role(
       $version = $postgresql::server::_version
     }
   
-    if ($dialect == 'postgres') {
-      $login_sql       = $login       ? { true => 'LOGIN',       default => 'NOLOGIN' }
-    } elsif ($dialect == 'redshift') {
-      if ($login != true) {
-        $login_sql = $login
-      } else {
-        $login_sql = ''
-      }
-    }
+    $login_sql       = $login       ? { true => 'LOGIN',       default => 'NOLOGIN' }
     $inherit_sql     = $inherit     ? { true => 'INHERIT',     default => 'NOINHERIT' }
     $createrole_sql  = $createrole  ? { true => "CREATE${role_keyword}",  default => "NOCREATE${role_keyword}" }
     $createdb_sql    = $createdb    ? { true => 'CREATEDB',    default => 'NOCREATEDB' }
@@ -187,13 +179,6 @@ define postgresql::server::role(
       postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" ${createrole_sql}":
         command => "ALTER ${role_keyword} \"${username}\" ${createrole_sql}",
         unless => "SELECT 1 FROM ${role_table} WHERE usename = '${username}' AND usesuper = ${createrole}",
-      }
-
-      # $login can act as a string in Redshift, which is useful for passing PASSWORD DISABLE
-      postgresql_psql {"${title}: ALTER ${role_keyword} \"${username}\" ${login_sql}":
-        command => "ALTER ${role_keyword} \"${username}\" ${login_sql}",
-        # pg_shadow cannot be selected from in Redshift, even by superusers. As such, this command will always be run when invoked.
-        #unless => "SELECT 1 FROM ${password_table} WHERE usename = '${username}' AND passwd = ''",
       }
     }
   

--- a/spec/unit/defines/server/role_spec.rb
+++ b/spec/unit/defines/server/role_spec.rb
@@ -239,27 +239,6 @@ describe 'postgresql::server::role', :type => :define do
     end
   end
 
-  context 'login set to PASSWORD DISABLE (redshift)' do
-
-    let :params do
-      {
-        :login => "PASSWORD DISABLE",
-      }
-    end
-  
-    let :pre_condition do
-     "class {'postgresql::server': dialect => 'redshift'}"
-    end
-  
-    it { is_expected.to contain_postgresql__server__role('test') }
-    it 'should have an alter statement to set PASSWORD DISABLE' do
-      is_expected.to contain_postgresql_psql('test: ALTER USER "test" PASSWORD DISABLE').with({
-        'command'     => "ALTER USER \"test\" PASSWORD DISABLE",
-        'port'        => "5432",
-      })
-    end
-  end
-
   context "with specific db connection settings - default port (redshift)" do
     let :params do
       {


### PR DESCRIPTION
Since we can't query pg_shadow, these would be run on every pass. This is suboptimal, because it clutters up puppet catalog runs and introduces logic that is difficult to reason about.

As a result, we no longer support ALTER statements for PASSWORD DISABLE, assuming this will be set up and updated manually.

This change leaves behavior in the presence of a password hash alone, despite introducing the same problem. Since it is not expected that the majority of consumers will store hardcoded password hash data in their puppet repository (for anything other than a transient puppet run), we allow this.