### PR TITLE
CREATE GROUP entities cannot be quoted. This fixes that error.

### DIFF
--- a/manifests/server/dbgroup.pp
+++ b/manifests/server/dbgroup.pp
@@ -46,7 +46,7 @@ define postgresql::server::dbgroup(
   }
 
   postgresql_psql { "${title}: CREATE GROUP ${groupname}":
-    command     => "CREATE GROUP '${groupname}'",
+    command     => "CREATE GROUP ${groupname}",
     unless      => "SELECT 1 FROM pg_group WHERE groname = '${groupname}'",
     environment => [],
     require     => Class['Postgresql::Server'],

--- a/spec/unit/defines/server/dbgroup_spec.rb
+++ b/spec/unit/defines/server/dbgroup_spec.rb
@@ -27,7 +27,7 @@ describe 'postgresql::server::dbgroup', :type => :define do
     it { is_expected.to contain_postgresql__server__dbgroup('test') }
     it 'should have create group for test' do
       is_expected.to contain_postgresql_psql('test: CREATE GROUP test').with({
-        'command'     => "CREATE GROUP 'test'",
+        'command'     => "CREATE GROUP test",
         'environment' => [],
         'unless'      => "SELECT 1 FROM pg_group WHERE groname = 'test'",
         'port'        => "5432",
@@ -57,7 +57,7 @@ describe 'postgresql::server::dbgroup', :type => :define do
     it { is_expected.to contain_postgresql__server__dbgroup('test') }
     it 'should have create group for test' do
       is_expected.to contain_postgresql_psql('test: CREATE GROUP test').with({
-        'command'     => "CREATE GROUP 'test'",
+        'command'     => "CREATE GROUP test",
         'environment' => [],
         'unless'      => "SELECT 1 FROM pg_group WHERE groname = 'test'",
         'port'        => "5432",


### PR DESCRIPTION
Groups would not have been functional in the previous version. This has been fixed.