### PR TITLE
Extract dbgroup members into a separate puppet class

### DIFF
--- a/spec/unit/defines/server/dbgroupmember_spec.rb
+++ b/spec/unit/defines/server/dbgroupmember_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe 'postgresql::server::dbgroupmember', :type => :define do
+
+  let :facts do
+    {
+      :osfamily => 'Debian',
+      :operatingsystem => 'Debian',
+      :operatingsystemrelease => '6.0',
+      :kernel => 'Linux',
+      :concat_basedir => tmpfilename('contrib'),
+      :id => 'root',
+      :path => '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+    }
+  end
+
+  let :title do
+    'test_user'
+  end
+
+  context 'group member present' do
+
+    let :pre_condition do
+     "class {'postgresql::server': dialect => 'postgres'}"
+    end
+
+    let :params do
+      {
+        :groupname => 'test',
+      }
+    end
+  
+    it { is_expected.to contain_postgresql__server__dbgroupmember('test_user') }
+    it 'should have create group for test' do
+      is_expected.to contain_postgresql_psql('test_user: ALTER GROUP test ADD USER test_user').with({
+        'command'     => "ALTER GROUP test ADD USER test_user",
+        'environment' => ["rp_env"],
+        'unless'      => "SELECT (SELECT usesysid from pg_user where usename = 'test_user') = ANY((SELECT grolist from pg_group where groname = 'test')::int[])",
+        'port'        => "5432",
+      })
+    end
+  end
+
+  context 'group member absent' do
+
+    let :pre_condition do
+     "class {'postgresql::server': dialect => 'postgres'}"
+    end
+  
+    let :params do
+      {
+        :ensure => 'absent',
+        :groupname => 'test',
+      }
+    end
+
+    it { is_expected.to contain_postgresql__server__dbgroupmember('test_user') }
+    it 'should have create group for test' do
+      is_expected.to contain_postgresql_psql('test_user: ALTER GROUP test DROP USER test_user').with({
+        'command'     => "ALTER GROUP test DROP USER test_user",
+        'environment' => ["rp_env"],
+        'unless'      => "SELECT NOT (SELECT usesysid from pg_user where usename = 'test_user') = ANY((SELECT grolist from pg_group where groname = 'test')::int[])",
+        'port'        => "5432",
+      })
+    end
+  end
+end


### PR DESCRIPTION
This marks a departure from previous syntax because Redshift's pg_group catalog cannot be updated directly. Furthermore, certain conveniences available to Postgres (such as loops and functions) are not available in Redshift, making direct group membership difficult.

As such, we expose these group members, including their ensure syntax, to the application. This allows fine grained control of membership, and allows consumers of this class to provide their own group management strategy -- including using puppet `generate` or application code to manage users programmatically.

We also allow consumers of this class to define their own `require` syntax, as we leave each class title ambiguous.