### PR TITLE
Update UNLESS syntax and environment

### DIFF
--- a/manifests/server/dbgroup.pp
+++ b/manifests/server/dbgroup.pp
@@ -41,7 +41,7 @@ define postgresql::server::dbgroup(
     postgresql_psql { "${title}: DROP GROUP ${groupname}":
       command     => "DROP GROUP ${groupname}",
       unless      => "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM pg_group WHERE groname = '${groupname}')",
-      environment => $environment,
+      environment => [],
       require     => Class['Postgresql::Server'],
     }
   } else {
@@ -61,7 +61,7 @@ define postgresql::server::dbgroup(
     postgresql_psql { "${title}: CREATE GROUP ${groupname}":
       command     => "CREATE GROUP ${groupname}",
       unless      => "SELECT 1 FROM pg_group WHERE groname = '${groupname}'",
-      environment => $environment,
+      environment => [],
       require     => Class['Postgresql::Server'],
     }
   }

--- a/manifests/server/dbgroupmember.pp
+++ b/manifests/server/dbgroupmember.pp
@@ -40,8 +40,8 @@ define postgresql::server::dbgroupmember(
     }
     postgresql_psql { "${title}: ALTER GROUP ${groupname} DROP USER ${username}":
       command     => "ALTER GROUP ${groupname} DROP USER ${username}",
-      unless      => "SELECT NOT (SELECT usesysid from pg_user where usename = '${username}') = ANY((SELECT grolist from pg_group where groname = '${groupname}')::int[])",
-      environment => $environment,
+      unless      => "SELECT 1 WHERE NOT (SELECT usesysid from pg_user where usename = '${username}') = ANY((SELECT grolist from pg_group where groname = '${groupname}')::int[])",
+      environment => [],
       require     => Class['Postgresql::Server'],
     }
   } else {
@@ -60,8 +60,8 @@ define postgresql::server::dbgroupmember(
     }
     postgresql_psql { "${title}: ALTER GROUP ${groupname} ADD USER ${username}":
       command     => "ALTER GROUP ${groupname} ADD USER ${username}",
-      unless      => "SELECT (SELECT usesysid from pg_user where usename = '${username}') = ANY((SELECT grolist from pg_group where groname = '${groupname}')::int[])",
-      environment => $environment,
+      unless      => "SELECT 1 WHERE (SELECT usesysid from pg_user where usename = '${username}') = ANY((SELECT grolist from pg_group where groname = '${groupname}')::int[])",
+      environment => [],
       require     => Class['Postgresql::Server'],
     }
   }

--- a/spec/unit/defines/server/dbgroup_spec.rb
+++ b/spec/unit/defines/server/dbgroup_spec.rb
@@ -28,7 +28,7 @@ describe 'postgresql::server::dbgroup', :type => :define do
     it 'should have create group for test' do
       is_expected.to contain_postgresql_psql('test: CREATE GROUP test').with({
         'command'     => "CREATE GROUP test",
-        'environment' => ["rp_env"],
+        'environment' => [],
         'unless'      => "SELECT 1 FROM pg_group WHERE groname = 'test'",
         'port'        => "5432",
       })
@@ -51,7 +51,7 @@ describe 'postgresql::server::dbgroup', :type => :define do
     it 'should have create group for test' do
       is_expected.to contain_postgresql_psql('test: DROP GROUP test').with({
         'command'     => "DROP GROUP test",
-        'environment' => ["rp_env"],
+        'environment' => [],
         'unless'      => "SELECT 1 WHERE NOT EXISTS (SELECT 1 FROM pg_group WHERE groname = 'test')",
         'port'        => "5432",
       })

--- a/spec/unit/defines/server/dbgroupmember_spec.rb
+++ b/spec/unit/defines/server/dbgroupmember_spec.rb
@@ -34,8 +34,8 @@ describe 'postgresql::server::dbgroupmember', :type => :define do
     it 'should have create group for test' do
       is_expected.to contain_postgresql_psql('test_user: ALTER GROUP test ADD USER test_user').with({
         'command'     => "ALTER GROUP test ADD USER test_user",
-        'environment' => ["rp_env"],
-        'unless'      => "SELECT (SELECT usesysid from pg_user where usename = 'test_user') = ANY((SELECT grolist from pg_group where groname = 'test')::int[])",
+        'environment' => [],
+        'unless'      => "SELECT 1 WHERE (SELECT usesysid from pg_user where usename = 'test_user') = ANY((SELECT grolist from pg_group where groname = 'test')::int[])",
         'port'        => "5432",
       })
     end
@@ -58,8 +58,8 @@ describe 'postgresql::server::dbgroupmember', :type => :define do
     it 'should have create group for test' do
       is_expected.to contain_postgresql_psql('test_user: ALTER GROUP test DROP USER test_user').with({
         'command'     => "ALTER GROUP test DROP USER test_user",
-        'environment' => ["rp_env"],
-        'unless'      => "SELECT NOT (SELECT usesysid from pg_user where usename = 'test_user') = ANY((SELECT grolist from pg_group where groname = 'test')::int[])",
+        'environment' => [],
+        'unless'      => "SELECT 1 WHERE NOT (SELECT usesysid from pg_user where usename = 'test_user') = ANY((SELECT grolist from pg_group where groname = 'test')::int[])",
         'port'        => "5432",
       })
     end


### PR DESCRIPTION
* UNLESS requires a SELECT statement, since it's evaluated by presence of any rows using a COUNT query. This fixes the check accordingly.
* $environment is not supported by dbgroup nor dbgroupmember. As such, we include it as a blank at this time. This may be changed in the future.