### PR TITLE
WIP: Support Redshift groups in grant statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1353,7 +1353,7 @@ Default value: the default user for the module, usually 'postgres'.
 
 ##### `role`
 
-Specifies the role or user whom you are granting access to.
+Specifies the role or user whom you are granting access to. In Redshift, this can be a username ("username") or a group ("GROUP groupname").
 
 #### postgresql::server::grant_role
 

--- a/README.md
+++ b/README.md
@@ -1587,7 +1587,7 @@ Specifies whether to grant the ability to create new databases with this role.
 Default value: `false`.
 
 ##### `createrole`
-Specifies whether to grant the ability to create new roles with this role.
+Specifies whether to grant the ability to create new roles with this role. In Redshift, this specifies the CREATEUSER permission instead.
 
 Default value: `false`.
 
@@ -1612,7 +1612,9 @@ Specifies whether to grant login capability for the new role.
 Default value: `true`.
 
 ##### `password_hash`
-Sets the hash to use during password creation. If the password is not already pre-encrypted in a format that PostgreSQL supports, use the `postgresql_password` function to provide an MD5 hash here, for example:
+Sets the hash to use during password creation. If the password is not already pre-encrypted in a format that PostgreSQL supports, use the `postgresql_password` function to provide an MD5 hash here.
+
+In Redshift, this can be set to false to specify PASSWORD DISABLE for new users. Note that this is not compatible with the CREATEUSER permission, and Redshift will raise an error if both are provided for the same user.
 
 ##### `update_password`
 If set to true, updates the password on changes. Set this to false to not modify the role's password after creation.

--- a/README.md
+++ b/README.md
@@ -1395,6 +1395,11 @@ Sets the OS user to run `psql`.
 
 Default value: the default user for the module, usually `postgres`.
 
+##### `dialect`
+In vanilla postgres, uses has_*_privilege functions for UNLESS evaluation. In Redshift, custom functions are used instead when a group is provided (as these functions do not support groups).
+
+Default value: inherit from server settings.
+
 ##### `connect_settings`
 
 Specifies a hash of environment variables used when connecting to a remote server.

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -310,10 +310,17 @@ define postgresql::server::grant (
     }
   }
 
-  if ($dialect == 'redshift' and $role =~ /^group (.*)/) {
-    # Built-in functions such as has_table_privilege don't work on groups in Redshift. As such, we have to dive into the low-level aclitem[] within pg_catalog.pg_class to find what we're looking for.
-    #
-    # This only works with object types that cleanly map to information_schema, and is incompatible with complex permission types. 
+  if ($dialect == 'redshift') {
+    # Built-in functions such as has_table_privilege don't work on
+    # groups in Redshift at this writing. Similarly,
+    # information_schema role tables do not appear to be consistently
+    # kept up to date. As such, we have to dive into the low-level
+    # aclitem[] within pg_catalog.pg_class to find what we're looking
+    # for.
+    # 
+    # This only works with object types that cleanly map to
+    # information_schema, and is incompatible with complex permission
+    # types.
     $_lowercase_object_type = $object_type ? {
         'ALL TABLES IN SCHEMA'    => 'table',
         'ALL SEQUENCES IN SCHEMA' => 'sequence',

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -323,7 +323,7 @@ define postgresql::server::grant (
   }
 
   $grant_cmd = "GRANT ${_privilege} ON ${_object_type} \"${_togrant_object}\" TO
-      \"${role}\""
+      ${role}"
   postgresql_psql { "${title}: grant:${name}":
     command          => $grant_cmd,
     db               => $on_db,
@@ -337,8 +337,13 @@ define postgresql::server::grant (
     require          => Class['postgresql::server']
   }
 
-  if($role != undef and defined(Postgresql::Server::Role[$role])) {
-    Postgresql::Server::Role[$role]->Postgresql_psql["${title}: grant:${name}"]
+  if($role != undef) {
+    if $role =~ /^GROUP (.*)/ {
+      if defined(Postgresql::Server::Dbgroup["#$1"]) {
+        Postgresql::Server::Dbgroup["#$1"]->Postgresql_psql["${title}: grant:${name}"]
+    } else if defined(Postgresql::Server::Role[$role])) {
+      Postgresql::Server::Role[$role]->Postgresql_psql["${title}: grant:${name}"]
+    }
   }
 
   if($db != undef and defined(Postgresql::Server::Database[$db])) {

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -128,10 +128,6 @@ define postgresql::server::role(
       $options_sql = "${createrole_sql} ${createdb_sql}"
     }
 
-    postgresql_psql {"ALTER ROLE \"${username}\" CONNECTION LIMIT ${connection_limit}":
-      unless => "SELECT 1 FROM pg_roles WHERE rolname = '${username}' AND rolconnlimit = ${connection_limit}",
-    }
-
     postgresql_psql { "${title}: CREATE ${role_keyword} ${username} ENCRYPTED PASSWORD ****":
       command     => "CREATE ${role_keyword} \"${username}\" ${password_sql} ${options_sql} CONNECTION LIMIT ${role_connection_limit}",
       unless      => "SELECT 1 FROM ${role_table} WHERE ${role_column_prefix}name = '${username}'",
@@ -206,10 +202,10 @@ define postgresql::server::role(
           environment => $environment,
         }
       } elsif ($dialect == 'redshift') {
-        warning('UNLESS clause support is not yet supported for setting password on Redshift users')
+        # pg_shadow cannot be selected from in Redshift, even by superusers. As such, this command will always be run when invoked.
+        warning('Due to lack of pg_shadow access, UNLESS clause support is not yet supported for setting password on Redshift users')
         postgresql_psql { "${title}: ALTER ${role_keyword} ${username} ENCRYPTED PASSWORD ****":
           command     => "ALTER ${role_keyword} \"${username}\" ${password_sql}",
-          # pg_shadow cannot be selected from in Redshift, even by superusers. As such, this command will always be run when invoked.
           #unless      => "SELECT 1 FROM ${password_table} WHERE usename = '${username}' AND passwd = '${pwd_hash_sql}'",
           environment => $environment,
         }

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -206,6 +206,7 @@ define postgresql::server::role(
           environment => $environment,
         }
       } elsif ($dialect == 'redshift') {
+        warning('UNLESS clause support is not yet supported for setting password on Redshift users')
         postgresql_psql { "${title}: ALTER ${role_keyword} ${username} ENCRYPTED PASSWORD ****":
           command     => "ALTER ${role_keyword} \"${username}\" ${password_sql}",
           # pg_shadow cannot be selected from in Redshift, even by superusers. As such, this command will always be run when invoked.

--- a/spec/unit/defines/server/grant_spec.rb
+++ b/spec/unit/defines/server/grant_spec.rb
@@ -152,7 +152,7 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
         'command' => /GRANT SELECT ON TABLE "test"."table" TO\s* group test/m,
-        'unless'  => /WHERE\s*nsp.nspname = 'test'\s*AND c.relname LIKE 'table'\s*AND c.reltype = 'table'/m,
+        'unless'  => /WHERE\s*nsp.nspname = 'test'\s*AND c.relname LIKE 'table'\s*AND t.typname = 'table'/m,
       }
     ) }
   end
@@ -176,7 +176,7 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
         'command' => /GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO\s* test/m,
-        'unless'  => /SELECT 1\s*WHERE FALSE IN\(\s*SELECT has_table_privilege\('test', 'public\.' \+ tablename, 'SELECT'\)\s*FROM pg_tables\s*WHERE schemaname = 'public'\)/m,
+        'unless'  => /WHERE\s*nsp.nspname = 'public'\s*AND c.relname LIKE '%'\s*AND t.typname = 'table'/m,
       }
     ) }
   end
@@ -200,7 +200,7 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
         'command' => /GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO\s* group test/m,
-        'unless'  => /WHERE\s*nsp.nspname = 'public'\s*AND c.relname LIKE '%'\s*AND c.reltype = 'table'/m,
+        'unless'  => /WHERE\s*nsp.nspname = 'public'\s*AND c.relname LIKE '%'\s*AND t.typname = 'table'/m,
       }
     ) }
   end

--- a/spec/unit/defines/server/grant_spec.rb
+++ b/spec/unit/defines/server/grant_spec.rb
@@ -115,6 +115,7 @@ describe 'postgresql::server::grant', :type => :define do
         :db => 'test',
         :role => 'test',
         :privilege => 'select',
+        :object_name => ['test', 'table'],
         :object_type => 'table',
       }
     end
@@ -126,8 +127,8 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
-        'command' => /GRANT USAGE ON TABLE "test" TO\s* GROUP test/m,
-        'unless'  => /SELECT 1 WHERE has_table_privilege\('GROUP test',\s* 'test', 'USAGE'\)/m,
+        'command' => /GRANT SELECT ON TABLE "test"."table" TO\s* test/m,
+        'unless'  => /SELECT 1 WHERE has_table_privilege\('test',\s* 'test.table', 'SELECT'\)/m,
       }
     ) }
   end
@@ -138,6 +139,7 @@ describe 'postgresql::server::grant', :type => :define do
         :db => 'test',
         :role => 'group test',
         :privilege => 'select',
+        :object_name => ['test', 'table'],
         :object_type => 'table',
       }
     end
@@ -149,8 +151,8 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
-        'command' => /GRANT USAGE ON TABLE "test" TO\s* GROUP test/m,
-        'unless'  => /SELECT 1 WHERE has_table_privilege\('GROUP test',\s* 'test', 'USAGE'\)/m,
+        'command' => /GRANT SELECT ON TABLE "test"."table" TO\s* group test/m,
+        'unless'  => /.*WHERE\s*nsp.nspname = 'test'\s*AND c.relname = 'table'\s*AND c.reltype = 'table'.*/m,
       }
     ) }
   end
@@ -159,7 +161,7 @@ describe 'postgresql::server::grant', :type => :define do
     let :params do
       {
         :db => 'test',
-        :role => 'GROUP test',
+        :role => 'group test',
         :privilege => 'select',
         :object_type => 'all tables in schema',
         :object_name => 'public',
@@ -173,8 +175,8 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
-        'command' => /GRANT USAGE ON ALL SEQUENCES IN SCHEMA "public" TO\s* GROUP test/m,
-        'unless'  => /SELECT 1 FROM \(\s*SELECT sequence_name\s* FROM information_schema\.sequences\s* WHERE sequence_schema='public'\s* EXCEPT DISTINCT\s* SELECT object_name as sequence_name\s* FROM .* WHERE .*grantee='test'\s* AND object_schema='public'\s* AND privilege_type='USAGE'\s*\) P\s* HAVING count\(P\.sequence_name\) = 0/m,
+        'command' => /GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO\s* group test/m,
+        'unless'  => nil,
       }
     ) }
   end

--- a/spec/unit/defines/server/grant_spec.rb
+++ b/spec/unit/defines/server/grant_spec.rb
@@ -152,7 +152,7 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
         'command' => /GRANT SELECT ON TABLE "test"."table" TO\s* group test/m,
-        'unless'  => /WHERE\s*nsp.nspname = 'test'\s*AND c.relname = 'table'\s*AND c.reltype = 'table'/m,
+        'unless'  => /WHERE\s*nsp.nspname = 'test'\s*AND c.relname LIKE 'table'\s*AND c.reltype = 'table'/m,
       }
     ) }
   end
@@ -200,7 +200,7 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
         'command' => /GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO\s* group test/m,
-        'unless'  => nil,
+        'unless'  => /WHERE\s*nsp.nspname = 'public'\s*AND c.relname LIKE '%'\s*AND c.reltype = 'table'/m,
       }
     ) }
   end

--- a/spec/unit/defines/server/role_spec.rb
+++ b/spec/unit/defines/server/role_spec.rb
@@ -175,7 +175,7 @@ describe 'postgresql::server::role', :type => :define do
     end
 
     it 'should not have alter role for "test" user with password as **** if update_password is false' do
-      is_expected.not_to contain_postgresql_psql('ALTER ROLE test ENCRYPTED PASSWORD ****')
+      is_expected.not_to contain_postgresql_psql('test: ALTER ROLE test ENCRYPTED PASSWORD ****')
     end
   end
 


### PR DESCRIPTION
Prototype support for Redshift groups within grant statements. Rationale follows.

Users work as normal, but it seems Redshift does not support groups in dialect of postgresql system information functions (eg, https://docs.aws.amazon.com/redshift/latest/dg/r_HAS_TABLE_PRIVILEGE.html). As such, we have to take a deep dive into [pg_class](https://www.postgresql.org/docs/8.0/static/catalog-pg-class.html)'s `aclitem[]` framework, checking for ACLs connected to `group <groupname>` in the underlying stringlike structure (eg, https://docs.aws.amazon.com/redshift/latest/dg/r_PG_DEFAULT_ACL.html).

This is, needless to say, elaborate and extremely messy. I'm open to better ways to extract this information if they exist, but I do not presently see these in Redshift's documentation.