### PR TITLE
More grant UNLESS fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1411,7 +1411,7 @@ Sets the OS user to run `psql`.
 Default value: the default user for the module, usually `postgres`.
 
 ##### `dialect`
-In vanilla postgres, uses has_*_privilege functions for UNLESS evaluation. In Redshift, custom functions are used instead when a group is provided (as these functions do not support groups).
+In vanilla postgres, uses privilege functions for UNLESS evaluation. In Redshift, custom functions are used instead when a group is provided (as these functions do not support groups).
 
 Default value: inherit from server settings.
 

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,7 +1,7 @@
 # Install client cli tool. See README.md for more details.
 class postgresql::client (
   Enum['file', 'absent'] $file_ensure        = 'file',
-  Stdlib::Absolutepath $validcon_script_path = $postgresql::params::validcon_script_path,
+  String[1] $validcon_script_path            = $postgresql::params::validcon_script_path,
   String[1] $package_name                    = $postgresql::params::client_package_name,
   String[1] $package_ensure                  = 'present'
 ) inherits postgresql::params {

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -344,17 +344,17 @@ define postgresql::server::grant (
          pg_namespace nsp
         WHERE nsp.nspname = '${_schema}')
       AND FALSE != ALL (SELECT charindex('USAGE',
-              case when charindex('r',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'SELECT' else '' end
-            ||case when charindex('w',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'UPDATE' else '' end
-            ||case when charindex('a',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'INSERT' else '' end
-            ||case when charindex('d',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'DELETE' else '' end
-            ||case when charindex('R',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'RULE' else '' end
-            ||case when charindex('x',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'REFERENCES' else '' end
-            ||case when charindex('t',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'TRIGGER' else '' end
-            ||case when charindex('X',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'EXECUTE' else '' end
-            ||case when charindex('U',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'USAGE' else '' end
-            ||case when charindex('C',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'CREATE' else '' end
-            ||case when charindex('T',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'TEMPORARY' else '' end) > 0
+              case when charindex('r',split_part(split_part(array_to_string(nspacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'SELECT' else '' end
+            ||case when charindex('w',split_part(split_part(array_to_string(nspacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'UPDATE' else '' end
+            ||case when charindex('a',split_part(split_part(array_to_string(nspacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'INSERT' else '' end
+            ||case when charindex('d',split_part(split_part(array_to_string(nspacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'DELETE' else '' end
+            ||case when charindex('R',split_part(split_part(array_to_string(nspacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'RULE' else '' end
+            ||case when charindex('x',split_part(split_part(array_to_string(nspacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'REFERENCES' else '' end
+            ||case when charindex('t',split_part(split_part(array_to_string(nspacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'TRIGGER' else '' end
+            ||case when charindex('X',split_part(split_part(array_to_string(nspacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'EXECUTE' else '' end
+            ||case when charindex('U',split_part(split_part(array_to_string(nspacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'USAGE' else '' end
+            ||case when charindex('C',split_part(split_part(array_to_string(nspacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'CREATE' else '' end
+            ||case when charindex('T',split_part(split_part(array_to_string(nspacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'TEMPORARY' else '' end) > 0
       from
         pg_namespace nsp
       WHERE

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -358,7 +358,7 @@ define postgresql::server::grant (
       from
         pg_namespace nsp
       WHERE
-        nsp.nspname = '${_schema}'"
+        nsp.nspname = '${_schema}')"
       $_unless = $_custom_unless
     } else {
       warning('pg_class does not expose enough information to provide an UNLESS statement. Please ensure your code only runs this statement on catalog refresh!')

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -341,7 +341,7 @@ define postgresql::server::grant (
       $_custom_unless = "SELECT 1 WHERE EXISTS (
       SELECT nsp.oid
         from
-         pg_namespace nsp on
+         pg_namespace nsp
         WHERE nsp.nspname = '${_schema}')
       AND FALSE != ALL (SELECT charindex('USAGE',
               case when charindex('r',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'SELECT' else '' end

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -329,39 +329,41 @@ define postgresql::server::grant (
     # Built-in functions such as has_table_privilege don't work on
     # groups in Redshift at this writing. Similarly,
     # information_schema role tables do not appear to be consistently
-    # kept up to date. As such, we have to dive into the low-level
-    # aclitem[] within pg_catalog.pg_class to find what we're looking
-    # for.
+    # kept up to date. We can extract aclitem[] information from
+    # pg_default_acl or pg_namespace, but it seems pg_class no longer
+    # exposes its relacl attribute. As such, we warn when we cannot
+    # select a suitable UNLESS strategy, allowing the consumer to
+    # update their catalog runs accordingly.
     #
     # See https://docs.aws.amazon.com/redshift/latest/dg/c_unsupported-postgresql-functions.html
     # for why we can't use the same custom loop as for postgres.
-    $_lowercase_object_type = $_object_type ? {
-      'ALL TABLES IN SCHEMA' => 'table',
-      default                => downcase($_object_type)
+    if $_object_type == 'SCHEMA' {
+      $_custom_unless = "SELECT 1 WHERE EXISTS (
+      SELECT nsp.oid
+        from
+         pg_namespace nsp on
+        WHERE nsp.nspname = '${_schema}')
+      AND FALSE != ALL (SELECT charindex('USAGE',
+              case when charindex('r',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'SELECT' else '' end
+            ||case when charindex('w',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'UPDATE' else '' end
+            ||case when charindex('a',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'INSERT' else '' end
+            ||case when charindex('d',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'DELETE' else '' end
+            ||case when charindex('R',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'RULE' else '' end
+            ||case when charindex('x',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'REFERENCES' else '' end
+            ||case when charindex('t',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'TRIGGER' else '' end
+            ||case when charindex('X',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'EXECUTE' else '' end
+            ||case when charindex('U',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'USAGE' else '' end
+            ||case when charindex('C',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'CREATE' else '' end
+            ||case when charindex('T',split_part(split_part(array_to_string(nspname, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'TEMPORARY' else '' end) > 0
+      from
+        pg_namespace nsp
+      WHERE
+        nsp.nspname = '${_schema}'"
+      $_unless = $_custom_unless
+    } else {
+      warning('pg_class does not expose enough information to provide an UNLESS statement. Please ensure your code only runs this statement on catalog refresh!')
+      $_unless = undef
     }
-    $_custom_unless = "SELECT 1 WHERE FALSE != ALL(SELECT charindex('${_privilege}', (SELECT substring(
-            case when charindex('r',split_part(split_part(array_to_string(relacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'SELECT' else '' end
-          ||case when charindex('w',split_part(split_part(array_to_string(relacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'UPDATE' else '' end
-          ||case when charindex('a',split_part(split_part(array_to_string(relacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'INSERT' else '' end
-          ||case when charindex('d',split_part(split_part(array_to_string(relacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'DELETE' else '' end
-          ||case when charindex('R',split_part(split_part(array_to_string(relacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'RULE' else '' end
-          ||case when charindex('x',split_part(split_part(array_to_string(relacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'REFERENCES' else '' end
-          ||case when charindex('t',split_part(split_part(array_to_string(relacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'TRIGGER' else '' end
-          ||case when charindex('X',split_part(split_part(array_to_string(relacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'EXECUTE' else '' end
-          ||case when charindex('U',split_part(split_part(array_to_string(relacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'USAGE' else '' end
-          ||case when charindex('C',split_part(split_part(array_to_string(relacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'CREATE' else '' end
-          ||case when charindex('T',split_part(split_part(array_to_string(relacl, '|'),'${_lowercase_role}',2 ) ,'/',1)) > 0 then 'TEMPORARY' else '' end
-       , 2,10000)
-    from
-    (SELECT c.relacl, c.relname, c.reltype FROM pg_class c
-     left join pg_namespace nsp on (c.relnamespace = nsp.oid)
-     left join pg_type t on (c.reltype = t.typnamespace)
-    WHERE
-     nsp.nspname = '${_schema}'
-     AND c.relname LIKE '${_relation}'
-     AND t.typname = '${_lowercase_object_type}'
-    ))) > 0)"
-    $_unless = $_custom_unless
   } else {
     $_unless = $unless_function ? {
         false    => undef,

--- a/spec/unit/defines/server/grant_spec.rb
+++ b/spec/unit/defines/server/grant_spec.rb
@@ -109,14 +109,14 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql__server__grant('test') }
   end
 
-  context 'table (to redshift user)' do
+  context 'schema (to redshift user)' do
     let :params do
       {
         :db => 'test',
         :role => 'test',
-        :privilege => 'select',
-        :object_name => ['test', 'table'],
-        :object_type => 'table',
+        :privilege => 'usage',
+        :object_name => 'test',
+        :object_type => 'schema',
       }
     end
 
@@ -127,20 +127,20 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
-        'command' => /GRANT SELECT ON TABLE "test"."table" TO\s* test/m,
-        'unless'  => /SELECT 1 WHERE has_table_privilege\('test',\s* 'test.table', 'SELECT'\)/m,
+        'command' => /GRANT USAGE ON SCHEMA "test" TO\s* test/m,
+        'unless'  => /SELECT 1 WHERE has_schema_privilege\('test',\s* 'test', 'USAGE'\)/m,
       }
     ) }
   end
 
-  context 'table (to group)' do
+  context 'schema (to group)' do
     let :params do
       {
         :db => 'test',
         :role => 'group test',
-        :privilege => 'select',
-        :object_name => ['test', 'table'],
-        :object_type => 'table',
+        :privilege => 'usage',
+        :object_name => 'test',
+        :object_type => 'schema',
       }
     end
 
@@ -151,8 +151,8 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
-        'command' => /GRANT SELECT ON TABLE "test"."table" TO\s* group test/m,
-        'unless'  => /WHERE\s*nsp.nspname = 'test'\s*AND c.relname LIKE 'table'\s*AND t.typname = 'table'/m,
+        'command' => /GRANT USAGE ON SCHEMA "test" TO\s* group test/m,
+        'unless'  => /WHERE\s*nsp.nspname = 'test'/m,
       }
     ) }
   end
@@ -176,7 +176,7 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
         'command' => /GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO\s* test/m,
-        'unless'  => /WHERE\s*nsp.nspname = 'public'\s*AND c.relname LIKE '%'\s*AND t.typname = 'table'/m,
+        'unless'  => nil,
       }
     ) }
   end
@@ -200,7 +200,7 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
         'command' => /GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO\s* group test/m,
-        'unless'  => /WHERE\s*nsp.nspname = 'public'\s*AND c.relname LIKE '%'\s*AND t.typname = 'table'/m,
+        'unless'  => nil,
       }
     ) }
   end


### PR DESCRIPTION
It turns out my grand plan to use [pg_class.relacl](https://www.postgresql.org/docs/8.0/static/catalog-pg-class.html) is spoiled by this field being NULL in the most recent versions of Redshift. This seems incredibly strange because pg_namespace and pg_default_acl still have their aclitem[] entries, and perhaps is a bug or documented permissions change that I'm unable to locate at this time.

Because this information is unavailable, #19 won't work in the general case. This review limits those change to the only ACL space we can scan ([pg_namespace]((https://www.postgresql.org/docs/8.0/static/catalog-pg-namespace.html))) in the context of grant statements, stubbing the remainder.

Because this prevents us from providing an UNLESS clause in these cases, users will need to find some other strategy to prevent these grants from being run with every puppet catalog refresh. One possibility is to use a conditional via [generate](https://docs.puppet.com/puppet/latest/function.html#generate) or [notifyonly](https://docs.puppet.com/puppet/latest/types/exec.html) in classes that consume this module.