### PR TITLE
Support refreshonly in top level classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1443,7 +1443,7 @@ Sets the OS user to run `psql`.
 Default value: the default user for the module, usually `postgres`.
 
 ##### `dialect`
-In vanilla postgres, uses has_*_privilege functions for UNLESS evaluation. In Redshift, custom functions are used instead when a group is provided (as these functions do not support groups).
+In vanilla postgres, uses privilege functions for UNLESS evaluation. In Redshift, custom functions are used instead when a group is provided (as these functions do not support groups).
 
 Default value: inherit from server settings.
 

--- a/README.md
+++ b/README.md
@@ -937,6 +937,14 @@ Specifies the path to the `psql` command.
 
 Default value: OS dependent.
 
+##### `refreshonly`
+
+Specifies whether to execute the SQL only if there is a notify or subscribe event.
+
+Valid values: `true`, `false`.
+
+Default value: `false`.
+
 ##### `service_manage`
 
 Defines whether or not Puppet should manage the service. 
@@ -1047,6 +1055,14 @@ Creates a local database, user, and assigns necessary permissions.
 
 Defines a comment to be stored about the database using the PostgreSQL COMMENT command.
 
+##### `refreshonly`
+
+Specifies whether to execute the SQL only if there is a notify or subscribe event.
+
+Valid values: `true`, `false`.
+
+Default value: Inherit from server.
+
 ##### `connect_settings`
 
 Specifies a hash of environment variables used when connecting to a remote server. 
@@ -1113,6 +1129,14 @@ User to create and assign access to the database upon creation. Mandatory.
 
 Creates a Postgres group.
 
+##### `refreshonly`
+
+Specifies whether to execute the SQL only if there is a notify or subscribe event.
+
+Valid values: `true`, `false`.
+
+Default value: Inherit from server.
+
 ##### `connect_settings`
 Required.
 
@@ -1151,6 +1175,14 @@ Default value: inherit from `$connect_settings` or `postgresql::server::port`
 #### postgresql::server::dbgroupmember
 
 Creates a member for an existing Postgres group.
+
+##### `refreshonly`
+
+Specifies whether to execute the SQL only if there is a notify or subscribe event.
+
+Valid values: `true`, `false`.
+
+Default value: Inherit from server.
 
 ##### `connect_settings`
 Required.
@@ -1415,6 +1447,14 @@ In vanilla postgres, uses has_*_privilege functions for UNLESS evaluation. In Re
 
 Default value: inherit from server settings.
 
+##### `refreshonly`
+
+Specifies whether to execute the SQL only if there is a notify or subscribe event.
+
+Valid values: `true`, `false`.
+
+Default value: Inherit from server.
+
 ##### `connect_settings`
 
 Specifies a hash of environment variables used when connecting to a remote server.
@@ -1540,6 +1580,14 @@ Port to use when connecting.
 
 Default value: `undef`, which generally defaults to port 5432 depending on your PostgreSQL packaging.
 
+##### `refreshonly`
+
+Specifies whether to execute the SQL only if there is a notify or subscribe event.
+
+Valid values: `true`, `false`.
+
+Default value: Inherit from server.
+
 ##### `connect_settings`
 
 Specifies a hash of environment variables used when connecting to a remote server.
@@ -1590,6 +1638,14 @@ Creates a role or user in PostgreSQL. In the Redshift dialect, this creates a ne
 Specifies how many concurrent connections the role can make.
 
 Default value: '-1', meaning no limit.
+
+##### `refreshonly`
+
+Specifies whether to execute the SQL only if there is a notify or subscribe event.
+
+Valid values: `true`, `false`.
+
+Default value: Inherit from server.
 
 ##### `connect_settings`
 Specifies a hash of environment variables used when connecting to a remote server.
@@ -1667,6 +1723,14 @@ Default value: the namevar.
 
 Creates a schema.
 
+##### `refreshonly`
+
+Specifies whether to execute the SQL only if there is a notify or subscribe event.
+
+Valid values: `true`, `false`.
+
+Default value: Inherit from server.
+
 ##### `connect_settings`
 
 Specifies a hash of environment variables used when connecting to a remote server.
@@ -1692,6 +1756,14 @@ Default value: the namevar.
 #### postgresql::server::table_grant
 
 Manages grant-based access privileges for users. Consult the PostgreSQL documentation for `grant` for more information.
+
+##### `refreshonly`
+
+Specifies whether to execute the SQL only if there is a notify or subscribe event.
+
+Valid values: `true`, `false`.
+
+Default value: Inherit from server.
 
 ##### `connect_settings`
 
@@ -1732,6 +1804,14 @@ Specifies the table to which you are granting access.
 #### postgresql::server::tablespace
 
 Creates a tablespace. If necessary, also creates the location and assigns the same permissions as the PostgreSQL server.
+
+##### `refreshonly`
+
+Specifies whether to execute the SQL only if there is a notify or subscribe event.
+
+Valid values: `true`, `false`.
+
+Default value: Inherit from server.
 
 ##### `connect_settings`
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class postgresql::params inherits postgresql::globals {
   $ipv4acls                   = []
   $ipv6acls                   = []
   $dialect                    = pick($dialect, 'postgres')
+  $refreshonly                = false
   $encoding                   = $postgresql::globals::encoding
   $locale                     = $postgresql::globals::locale
   $data_checksums             = $postgresql::globals::data_checksums

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -52,6 +52,7 @@ class postgresql::server (
   $locale                     = $postgresql::params::locale,
   $data_checksums             = $postgresql::params::data_checksums,
   $timezone                   = $postgresql::params::timezone,
+  $refreshonly                = $postgresql::params::refreshonly,
 
   $manage_pg_hba_conf         = $postgresql::params::manage_pg_hba_conf,
   $manage_pg_ident_conf       = $postgresql::params::manage_pg_ident_conf,

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -8,6 +8,7 @@ define postgresql::server::database(
   $encoding         = $postgresql::server::encoding,
   $locale           = $postgresql::server::locale,
   $istemplate       = false,
+  $refreshonly      = $postgresql::server::refreshonly,
   $connect_settings = $postgresql::server::default_connect_settings,
 ) {
   $createdb_path = $postgresql::server::createdb_path
@@ -39,6 +40,7 @@ define postgresql::server::database(
     psql_path        => $psql_path,
     port             => $port,
     connect_settings => $connect_settings,
+    refreshonly      => $refreshonly,
   }
 
   # Optionally set the locale switch. Older versions of createdb may not accept

--- a/manifests/server/database_grant.pp
+++ b/manifests/server/database_grant.pp
@@ -5,6 +5,7 @@ define postgresql::server::database_grant(
   $role,
   $psql_db          = undef,
   $psql_user        = undef,
+  $refreshonly      = $postgresql::server::refreshonly,
   $connect_settings = undef,
 ) {
   postgresql::server::grant { "database:${name}":
@@ -16,5 +17,6 @@ define postgresql::server::database_grant(
     psql_db          => $psql_db,
     psql_user        => $psql_user,
     connect_settings => $connect_settings,
+    refreshonly      => $refreshonly,
   }
 }

--- a/manifests/server/dbgroup.pp
+++ b/manifests/server/dbgroup.pp
@@ -5,6 +5,7 @@ define postgresql::server::dbgroup(
   $ensure           = 'present',
   $groupname        = $title,
   $dialect          = $postgresql::server::dialect,
+  $refreshonly      = $postgresql::server::refreshonly,
   $connect_settings = undef,
 ) {
   $psql_user      = $postgresql::server::user

--- a/manifests/server/dbgroupmember.pp
+++ b/manifests/server/dbgroupmember.pp
@@ -6,6 +6,7 @@ define postgresql::server::dbgroupmember(
   $groupname        = undef,
   $username         = $title,
   $dialect          = $postgresql::server::dialect,
+  $refreshonly      = $postgresql::server::refreshonly,
   $connect_settings = undef,
 ) {
   $psql_user      = $postgresql::server::user

--- a/manifests/server/dbgroupmember.pp
+++ b/manifests/server/dbgroupmember.pp
@@ -35,12 +35,12 @@ define postgresql::server::dbgroupmember(
       connect_settings => $connect_settings,
       cwd              => $module_workdir,
       require          => [
-        Postgresql_psql["${title}: ALTER GROUP ${groupname} DROP USER ${username}"],
+        Postgresql_psql["${title}: ALTER GROUP ${groupname} DROP USER \"${username}\""],
         Class['postgresql::server'],
       ],
     }
-    postgresql_psql { "${title}: ALTER GROUP ${groupname} DROP USER ${username}":
-      command     => "ALTER GROUP ${groupname} DROP USER ${username}",
+    postgresql_psql { "${title}: ALTER GROUP ${groupname} DROP USER \"${username}\"":
+      command     => "ALTER GROUP ${groupname} DROP USER \"${username}\"",
       unless      => "SELECT 1 WHERE NOT (SELECT usesysid from pg_user where usename = '${username}') = ANY((SELECT grolist from pg_group where groname = '${groupname}')::int[])",
       environment => [],
       require     => Class['Postgresql::Server'],
@@ -55,12 +55,12 @@ define postgresql::server::dbgroupmember(
       connect_settings => $connect_settings,
       cwd        => $module_workdir,
       require    => [
-        Postgresql_psql["${title}: ALTER GROUP ${groupname} ADD USER ${username}"],
+        Postgresql_psql["${title}: ALTER GROUP ${groupname} ADD USER \"${username}\""],
         Class['postgresql::server'],
       ],
     }
-    postgresql_psql { "${title}: ALTER GROUP ${groupname} ADD USER ${username}":
-      command     => "ALTER GROUP ${groupname} ADD USER ${username}",
+    postgresql_psql { "${title}: ALTER GROUP ${groupname} ADD USER \"${username}\"":
+      command     => "ALTER GROUP ${groupname} ADD USER \"${username}\"",
       unless      => "SELECT 1 WHERE (SELECT usesysid from pg_user where usename = '${username}') = ANY((SELECT grolist from pg_group where groname = '${groupname}')::int[])",
       environment => [],
       require     => Class['Postgresql::Server'],

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -27,6 +27,7 @@ define postgresql::server::grant (
   Integer $port                    = $postgresql::server::port,
   Boolean $onlyif_exists           = false,
   String $dialect                  = $postgresql::server::dialect,
+  Boolean $refreshonly             = $postgresql::server::refreshonly,
   Hash $connect_settings           = $postgresql::server::default_connect_settings,
 ) {
 
@@ -389,6 +390,7 @@ define postgresql::server::grant (
     psql_path        => $psql_path,
     unless           => $_unless,
     onlyif           => $_onlyif,
+    refreshonly      => $refreshonly,
     require          => Class['postgresql::server']
   }
 

--- a/manifests/server/grant_role.pp
+++ b/manifests/server/grant_role.pp
@@ -6,6 +6,7 @@ define postgresql::server::grant_role (
   $psql_db                          = $postgresql::server::default_database,
   $psql_user                        = $postgresql::server::user,
   $port                             = $postgresql::server::port,
+  $refreshonly                      = $postgresql::server::refreshonly,
   $connect_settings                 = $postgresql::server::default_connect_settings,
 ) {
   case $ensure {
@@ -29,6 +30,7 @@ define postgresql::server::grant_role (
     psql_user        => $psql_user,
     port             => $port,
     connect_settings => $connect_settings,
+    refreshonly      => $refreshonly,
   }
 
   if ! $connect_settings or empty($connect_settings) {

--- a/manifests/server/reassign_owned_by.pp
+++ b/manifests/server/reassign_owned_by.pp
@@ -6,6 +6,7 @@ define postgresql::server::reassign_owned_by (
   String $db,
   String $psql_user                 = $postgresql::server::user,
   Integer $port                     = $postgresql::server::port,
+  Boolean $refreshonly              = $postgresql::server::refreshonly,
   Hash $connect_settings            = $postgresql::server::default_connect_settings,
 ) {
 
@@ -45,6 +46,7 @@ define postgresql::server::reassign_owned_by (
     psql_group       => $group,
     psql_path        => $psql_path,
     onlyif           => $onlyif,
+    refreshonly      => $refreshonly,
     require          => Class['postgresql::server']
   }
 

--- a/manifests/server/role.pp
+++ b/manifests/server/role.pp
@@ -14,6 +14,7 @@ define postgresql::server::role(
   $connection_limit = '-1',
   $username         = $title,
   $dialect          = $postgresql::server::dialect,
+  $refreshonly      = $postgresql::server::refreshonly,
   $connect_settings = $postgresql::server::default_connect_settings,
 ) {
   $psql_user      = $postgresql::server::user
@@ -64,6 +65,7 @@ define postgresql::server::role(
       psql_path        => $psql_path,
       connect_settings => $connect_settings,
       cwd              => $module_workdir,
+      refreshonly      => $refreshonly,
       require          => [
         Postgresql_psql["${title}: DROP ${role_keyword} ${username}"],
         Class['postgresql::server'],
@@ -116,6 +118,7 @@ define postgresql::server::role(
       psql_path        => $psql_path,
       connect_settings => $connect_settings,
       cwd              => $module_workdir,
+      refreshonly      => $refreshonly,
       require          => [
         Postgresql_psql["${title}: CREATE ${role_keyword} ${username} ENCRYPTED PASSWORD ****"],
         Class['postgresql::server'],

--- a/manifests/server/schema.pp
+++ b/manifests/server/schema.pp
@@ -16,6 +16,7 @@ define postgresql::server::schema(
   $db               = $postgresql::server::default_database,
   $owner            = undef,
   $schema           = $title,
+  $refreshonly      = $postgresql::server::refreshonly,
   $connect_settings = $postgresql::server::default_connect_settings,
 ) {
   $user           = $postgresql::server::user
@@ -41,6 +42,7 @@ define postgresql::server::schema(
     port       => $port,
     cwd        => $module_workdir,
     connect_settings => $connect_settings,
+    refreshonly      => $refreshonly,
   }
 
   postgresql_psql { "${db}: CREATE SCHEMA \"${schema}\"":

--- a/manifests/server/table_grant.pp
+++ b/manifests/server/table_grant.pp
@@ -8,6 +8,7 @@ define postgresql::server::table_grant(
   $port             = undef,
   $psql_db          = undef,
   $psql_user        = undef,
+  $refreshonly      = $postgresql::server::refreshonly,
   $connect_settings = undef,
   $onlyif_exists    = false,
 ) {
@@ -22,5 +23,6 @@ define postgresql::server::table_grant(
     psql_user        => $psql_user,
     onlyif_exists    => $onlyif_exists,
     connect_settings => $connect_settings,
+    refreshonly      => $refreshonly,
   }
 }

--- a/manifests/server/tablespace.pp
+++ b/manifests/server/tablespace.pp
@@ -3,6 +3,7 @@ define postgresql::server::tablespace(
   $location,
   $owner   = undef,
   $spcname = $title,
+  $refreshonly      = $postgresql::server::refreshonly,
   $connect_settings = $postgresql::server::default_connect_settings,
 ) {
   $user           = $postgresql::server::user
@@ -24,6 +25,7 @@ define postgresql::server::tablespace(
     port             => $port,
     connect_settings => $connect_settings,
     cwd              => $module_workdir,
+    refreshonly      => $refreshonly,
   }
 
   file { $location:

--- a/spec/unit/defines/server/dbgroupmember_spec.rb
+++ b/spec/unit/defines/server/dbgroupmember_spec.rb
@@ -32,8 +32,8 @@ describe 'postgresql::server::dbgroupmember', :type => :define do
   
     it { is_expected.to contain_postgresql__server__dbgroupmember('test_user') }
     it 'should have create group for test' do
-      is_expected.to contain_postgresql_psql('test_user: ALTER GROUP test ADD USER test_user').with({
-        'command'     => "ALTER GROUP test ADD USER test_user",
+      is_expected.to contain_postgresql_psql('test_user: ALTER GROUP test ADD USER \"test_user\"').with({
+        'command'     => "ALTER GROUP test ADD USER \"test_user\"",
         'environment' => [],
         'unless'      => "SELECT 1 WHERE (SELECT usesysid from pg_user where usename = 'test_user') = ANY((SELECT grolist from pg_group where groname = 'test')::int[])",
         'port'        => "5432",
@@ -56,8 +56,8 @@ describe 'postgresql::server::dbgroupmember', :type => :define do
 
     it { is_expected.to contain_postgresql__server__dbgroupmember('test_user') }
     it 'should have create group for test' do
-      is_expected.to contain_postgresql_psql('test_user: ALTER GROUP test DROP USER test_user').with({
-        'command'     => "ALTER GROUP test DROP USER test_user",
+      is_expected.to contain_postgresql_psql('test_user: ALTER GROUP test DROP USER \"test_user\"').with({
+        'command'     => "ALTER GROUP test DROP USER \"test_user\"",
         'environment' => [],
         'unless'      => "SELECT 1 WHERE NOT (SELECT usesysid from pg_user where usename = 'test_user') = ANY((SELECT grolist from pg_group where groname = 'test')::int[])",
         'port'        => "5432",

--- a/spec/unit/defines/server/dbgroupmember_spec.rb
+++ b/spec/unit/defines/server/dbgroupmember_spec.rb
@@ -32,7 +32,7 @@ describe 'postgresql::server::dbgroupmember', :type => :define do
   
     it { is_expected.to contain_postgresql__server__dbgroupmember('test_user') }
     it 'should have create group for test' do
-      is_expected.to contain_postgresql_psql('test_user: ALTER GROUP test ADD USER \"test_user\"').with({
+      is_expected.to contain_postgresql_psql('test_user: ALTER GROUP test ADD USER "test_user"').with({
         'command'     => "ALTER GROUP test ADD USER \"test_user\"",
         'environment' => [],
         'unless'      => "SELECT 1 WHERE (SELECT usesysid from pg_user where usename = 'test_user') = ANY((SELECT grolist from pg_group where groname = 'test')::int[])",
@@ -56,7 +56,7 @@ describe 'postgresql::server::dbgroupmember', :type => :define do
 
     it { is_expected.to contain_postgresql__server__dbgroupmember('test_user') }
     it 'should have create group for test' do
-      is_expected.to contain_postgresql_psql('test_user: ALTER GROUP test DROP USER \"test_user\"').with({
+      is_expected.to contain_postgresql_psql('test_user: ALTER GROUP test DROP USER "test_user"').with({
         'command'     => "ALTER GROUP test DROP USER \"test_user\"",
         'environment' => [],
         'unless'      => "SELECT 1 WHERE NOT (SELECT usesysid from pg_user where usename = 'test_user') = ANY((SELECT grolist from pg_group where groname = 'test')::int[])",

--- a/spec/unit/defines/server/role_spec.rb
+++ b/spec/unit/defines/server/role_spec.rb
@@ -18,6 +18,21 @@ describe 'postgresql::server::role', :type => :define do
     'test'
   end
 
+  context 'refreshonly' do
+
+    let :params do
+      {
+        :password_hash => 'new-pa$s',
+      }
+    end
+
+    let :pre_condition do
+     "class {'postgresql::server': refreshonly => true}"
+    end
+
+    it { is_expected.to contain_postgresql__server__role('test') }
+  end
+
   context 'standalone' do
 
     let :params do
@@ -25,11 +40,11 @@ describe 'postgresql::server::role', :type => :define do
         :password_hash => 'new-pa$s',
       }
     end
-  
+
     let :pre_condition do
      "class {'postgresql::server':}"
     end
-  
+
     it { is_expected.to contain_postgresql__server__role('test') }
     it 'should have create role for "test" user with password as ****' do
       is_expected.to contain_postgresql_psql('test: CREATE ROLE test ENCRYPTED PASSWORD ****').with({
@@ -54,11 +69,11 @@ describe 'postgresql::server::role', :type => :define do
     let :params do
       {}
     end
-  
+
     let :pre_condition do
      "class {'postgresql::server': dialect => 'postgres'}"
     end
-  
+
     it { is_expected.to contain_postgresql__server__role('test') }
     it 'should have create role for "test" user with password as ****' do
       is_expected.to contain_postgresql_psql('test: CREATE ROLE test ENCRYPTED PASSWORD ****').with({
@@ -217,11 +232,11 @@ describe 'postgresql::server::role', :type => :define do
         :password_hash => 'new-pa$s',
       }
     end
-  
+
     let :pre_condition do
      "class {'postgresql::server': dialect => 'redshift'}"
     end
-  
+
     it { is_expected.to contain_postgresql__server__role('test') }
     it 'should have create role for "test" user with password as ****' do
       is_expected.to contain_postgresql_psql('test: CREATE USER test ENCRYPTED PASSWORD ****').with({
@@ -245,11 +260,11 @@ describe 'postgresql::server::role', :type => :define do
     let :params do
       {}
     end
-  
+
     let :pre_condition do
      "class {'postgresql::server': dialect => 'redshift'}"
     end
-  
+
     it { is_expected.to contain_postgresql__server__role('test') }
     it 'should have create role for "test" user with password as ****' do
       is_expected.to contain_postgresql_psql('test: CREATE USER test ENCRYPTED PASSWORD ****').with({


### PR DESCRIPTION
The [underlying class that executes a psql shell](https://github.com/puppetlabs/puppetlabs-postgresql/blob/84454c6a7471249f745d3dc1b6f195b5b38cc3f7/lib/puppet/type/postgresql_psql.rb#L115) supports [Puppet refresh logic](https://www.safaribooksonline.com/library/view/puppet-types-and/9781449339319/ch04.html), including the refreshonly parameter used to define [notification relationships between puppet classes](https://docs.puppet.com/puppet/5.3/lang_relationships.html#refreshing-and-notification).

This review elevates that parameter for use by most classes in this module, including defining default behavior in `postgresql::server` and default parameters (the default still being `false`). Other unrelated bugfixes are also included.

The goal being: we would like to allow postgres commands to only run when a refresh command is given (eg, when hieradata files describing the class structure are updated). This will substantially reduce puppet update times otherwise, since a large number of UNLESS queries can still be expensive to run at every catalog update.