### PR TITLE
Ensure role component is always quoted (either as "username" or group "groupname")

### DIFF
--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -380,8 +380,14 @@ define postgresql::server::grant (
     default           => undef,
   }
 
+  if ($role =~ /^group (.*)/) {
+    $_quoted_role = "group \"$1\""
+  } else {
+    $_quoted_role = "\"${role}\""
+  }
+
   $grant_cmd = "GRANT ${_privilege} ON ${_object_type} \"${_togrant_object}\" TO
-      ${role}"
+      ${_quoted_role}"
   postgresql_psql { "${title}: grant:${name}":
     command          => $grant_cmd,
     db               => $on_db,

--- a/spec/unit/defines/server/grant_spec.rb
+++ b/spec/unit/defines/server/grant_spec.rb
@@ -49,7 +49,7 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
-        'command' => /GRANT USAGE ON SEQUENCE "test" TO\s* test/m,
+        'command' => /GRANT USAGE ON SEQUENCE "test" TO\s* "test"/m,
         'unless'  => /SELECT 1 WHERE has_sequence_privilege\('test',\s* 'test', 'USAGE'\)/m,
       }
     ) }
@@ -73,7 +73,7 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
-        'command' => /GRANT USAGE ON ALL SEQUENCES IN SCHEMA "public" TO\s* test/m,
+        'command' => /GRANT USAGE ON ALL SEQUENCES IN SCHEMA "public" TO\s* "test"/m,
         'unless'  => /SELECT 1 FROM \(\s*SELECT sequence_name\s* FROM information_schema\.sequences\s* WHERE sequence_schema='public'\s* EXCEPT DISTINCT\s* SELECT object_name as sequence_name\s* FROM .* WHERE .*grantee='test'\s* AND object_schema='public'\s* AND privilege_type='USAGE'\s*\) P\s* HAVING count\(P\.sequence_name\) = 0/m,
       }
     ) }
@@ -127,7 +127,7 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
-        'command' => /GRANT USAGE ON SCHEMA "test" TO\s* test/m,
+        'command' => /GRANT USAGE ON SCHEMA "test" TO\s* "test"/m,
         'unless'  => /SELECT 1 WHERE has_schema_privilege\('test',\s* 'test', 'USAGE'\)/m,
       }
     ) }
@@ -151,7 +151,7 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
-        'command' => /GRANT USAGE ON SCHEMA "test" TO\s* group test/m,
+        'command' => /GRANT USAGE ON SCHEMA "test" TO\s* group "test"/m,
         'unless'  => /WHERE\s*nsp.nspname = 'test'/m,
       }
     ) }
@@ -175,7 +175,7 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
-        'command' => /GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO\s* test/m,
+        'command' => /GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO\s* "test"/m,
         'unless'  => nil,
       }
     ) }
@@ -199,7 +199,7 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
-        'command' => /GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO\s* group test/m,
+        'command' => /GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO\s* group "test"/m,
         'unless'  => nil,
       }
     ) }
@@ -222,7 +222,7 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
-        'command' => /GRANT USAGE ON SEQUENCE "test" TO\s* test/m,
+        'command' => /GRANT USAGE ON SEQUENCE "test" TO\s* "test"/m,
         'unless'  => /SELECT 1 WHERE has_sequence_privilege\('test',\s* 'test', 'USAGE'\)/m,
       }
     ) }
@@ -303,7 +303,7 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
-        'command' => /GRANT ALL ON TABLE "myschema"."mytable" TO\s* test/m,
+        'command' => /GRANT ALL ON TABLE "myschema"."mytable" TO\s* "test"/m,
         'unless'  => /SELECT 1 WHERE has_table_privilege\('test',\s*'myschema.mytable', 'INSERT'\)/m,
       }
     ) }


### PR DESCRIPTION
Both to prevent injection cases and to fix trivial syntax errors (eg, hyphens appearing in the role name).