### PR TITLE
Fix bug where groups were not being quoted correctly

### DIFF
--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -386,8 +386,7 @@ define postgresql::server::grant (
     $_quoted_role = "\"${role}\""
   }
 
-  $grant_cmd = "GRANT ${_privilege} ON ${_object_type} \"${_togrant_object}\" TO
-      ${_quoted_role}"
+  $grant_cmd = "GRANT ${_privilege} ON ${_object_type} \"${_togrant_object}\" TO ${_quoted_role}"
   postgresql_psql { "${title}: grant:${name}":
     command          => $grant_cmd,
     db               => $on_db,

--- a/manifests/server/grant.pp
+++ b/manifests/server/grant.pp
@@ -380,8 +380,8 @@ define postgresql::server::grant (
     default           => undef,
   }
 
-  if ($role =~ /^group (.*)/) {
-    $_quoted_role = "group \"${1}\""
+  if ($_lowercase_role =~ /^group (.*)/) {
+    $_quoted_role = "GROUP \"${1}\""
   } else {
     $_quoted_role = "\"${role}\""
   }

--- a/spec/unit/defines/server/grant_spec.rb
+++ b/spec/unit/defines/server/grant_spec.rb
@@ -133,6 +133,30 @@ describe 'postgresql::server::grant', :type => :define do
     ) }
   end
 
+  context 'schema (to group)' do
+    let :params do
+      {
+        :db => 'test',
+        :role => 'group test',
+        :privilege => 'usage',
+        :object_name => 'test',
+        :object_type => 'schema',
+      }
+    end
+
+    let :pre_condition do
+      "class {'postgresql::server': dialect => 'redshift'}"
+    end
+
+    it { is_expected.to contain_postgresql__server__grant('test') }
+    it { is_expected.to contain_postgresql_psql('test: grant:test').with(
+      {
+        'command' => /GRANT USAGE ON SCHEMA "test" TO\s* GROUP "test"/m,
+        'unless'  => /WHERE\s*nsp.nspname = 'test'/m,
+      }
+    ) }
+  end
+
   context 'schema (to GROUP)' do
     let :params do
       {

--- a/spec/unit/defines/server/grant_spec.rb
+++ b/spec/unit/defines/server/grant_spec.rb
@@ -83,7 +83,7 @@ describe 'postgresql::server::grant', :type => :define do
     let :params do
       {
         :db => 'test',
-        :role => 'group test',
+        :role => 'GROUP test',
       }
     end
 
@@ -94,11 +94,11 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to raise_error(Puppet::Error, /GROUP syntax is only available in the Redshift dialect/) }
   end
 
-  context 'plain (to group)' do
+  context 'plain (to GROUP)' do
     let :params do
       {
         :db => 'test',
-        :role => 'group test',
+        :role => 'GROUP test',
       }
     end
 
@@ -133,11 +133,11 @@ describe 'postgresql::server::grant', :type => :define do
     ) }
   end
 
-  context 'schema (to group)' do
+  context 'schema (to GROUP)' do
     let :params do
       {
         :db => 'test',
-        :role => 'group test',
+        :role => 'GROUP test',
         :privilege => 'usage',
         :object_name => 'test',
         :object_type => 'schema',
@@ -151,7 +151,7 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
-        'command' => /GRANT USAGE ON SCHEMA "test" TO\s* group "test"/m,
+        'command' => /GRANT USAGE ON SCHEMA "test" TO\s* GROUP "test"/m,
         'unless'  => /WHERE\s*nsp.nspname = 'test'/m,
       }
     ) }
@@ -181,11 +181,11 @@ describe 'postgresql::server::grant', :type => :define do
     ) }
   end
 
-  context 'all tables (to group)' do
+  context 'all tables (to GROUP)' do
     let :params do
       {
         :db => 'test',
-        :role => 'group test',
+        :role => 'GROUP test',
         :privilege => 'select',
         :object_type => 'all tables in schema',
         :object_name => 'public',
@@ -199,7 +199,7 @@ describe 'postgresql::server::grant', :type => :define do
     it { is_expected.to contain_postgresql__server__grant('test') }
     it { is_expected.to contain_postgresql_psql('test: grant:test').with(
       {
-        'command' => /GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO\s* group "test"/m,
+        'command' => /GRANT SELECT ON ALL TABLES IN SCHEMA "public" TO\s* GROUP "test"/m,
         'unless'  => nil,
       }
     ) }


### PR DESCRIPTION
due to what was a case sensitive regex match

Still trying to work out how to test this. I was able to run the unit tests, but there were dozens and dozens of errors before my change so 🤷‍♂


edit: ah cool, there is a travis build. At least the tests I care about run on the oldest version of ruby in the test suite :) 

Perfect. The change alone caused the tests to fail (https://travis-ci.com/github/Yelp/puppetlabs-postgresql/jobs/300978638) and then fixing the tests to match the new expectations fixes them (https://travis-ci.com/github/Yelp/puppetlabs-postgresql/jobs/300979457)

I also added additional test coverage to prove this is now case insensitive